### PR TITLE
Get rid of method overloading for timer.time to help type inference

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/Timer.scala
+++ b/src/main/scala/nl/grons/metrics/scala/Timer.scala
@@ -50,7 +50,7 @@ class Timer(private val metric: CHTimer) {
   /**
    * Wraps partial function pf, timing every execution
    */
-   def time[A,B](pf: PartialFunction[A,B]): PartialFunction[A,B] =
+   def timePF[A,B](pf: PartialFunction[A,B]): PartialFunction[A,B] =
      new PartialFunction[A,B] {
        def apply(a: A): B = {
            val ctx = timerContext()

--- a/src/main/scala_2.10/nl/grons/metrics/scala/ActorMetrics.scala
+++ b/src/main/scala_2.10/nl/grons/metrics/scala/ActorMetrics.scala
@@ -80,7 +80,7 @@ trait ReceiveTimerActor extends Actor { self: InstrumentedBuilder =>
   def receiveTimerName: String = MetricBuilder.metricName(getClass, Seq("receiveTimer"))
   lazy val timer: Timer = metrics.timer(receiveTimerName)
 
-  private[this] lazy val wrapped = timer.time(super.receive)
+  private[this] lazy val wrapped = timer.timePF(super.receive)
 
   abstract override def receive = wrapped
 }

--- a/src/test/scala_2.10/nl/grons/metrics/scala/ActorMetricsSpec.scala
+++ b/src/test/scala_2.10/nl/grons/metrics/scala/ActorMetricsSpec.scala
@@ -43,7 +43,7 @@ object TestFixture {
 
     when(mockTimer.timerContext()).thenReturn(mockTimerContext)
     when(mockCounter.count(any[PartialFunction[Any,Unit]])).thenReturn(pf)
-    when(mockTimer.time(any[PartialFunction[Any,Unit]])).thenReturn(pf)
+    when(mockTimer.timePF(any[PartialFunction[Any,Unit]])).thenReturn(pf)
     when(mockMeter.exceptionMarkerPartialFunction).thenReturn(new { def apply[A,B](pf: PartialFunction[A,B]): PartialFunction[A,B] = pf })
   }
 
@@ -113,7 +113,7 @@ class ActorMetricsSpec extends FunSpec with ShouldMatchers {
       val fixture = new Fixture
       val ref = TestActorRef(new TimerTestActor(fixture))
       ref ! "test"
-      verify(fixture.mockTimer).time(any[PartialFunction[Any,Unit]])
+      verify(fixture.mockTimer).timePF(any[PartialFunction[Any,Unit]])
     }
   }
 
@@ -132,7 +132,7 @@ class ActorMetricsSpec extends FunSpec with ShouldMatchers {
       val ref = TestActorRef(new ComposedActor(fixture))
       ref ! "test"
       verify(fixture.mockCounter).count(any[PartialFunction[Any,Unit]])
-      verify(fixture.mockTimer).time(any[PartialFunction[Any,Unit]])
+      verify(fixture.mockTimer).timePF(any[PartialFunction[Any,Unit]])
       verify(fixture.mockMeter,never()).mark()
       ref.underlyingActor.counterName should equal ("nl.grons.metrics.scala.TestFixture.ComposedActor.receiveCounter")
     }


### PR DESCRIPTION
fixes issue #13

Move away from method overloading, it's unnecessary and complicates usage rather than simplifies.  Should eliminate any type inference confusion.
