### PR TITLE
Add support for health checks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.codahale.metrics" % "metrics-core" % "3.0.1",
+  "com.codahale.metrics" % "metrics-healthchecks" % "3.0.1",
   "junit" % "junit" % "4.11" % "test",
   "org.scalatest" %% "scalatest" % "1.9.1" % "test",
   "org.mockito" % "mockito-all" % "1.9.5" % "test"

--- a/src/main/scala/nl/grons/metrics/scala/HealthChecks.scala
+++ b/src/main/scala/nl/grons/metrics/scala/HealthChecks.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2013-2013 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.grons.metrics.scala
+
+import com.codahale.metrics.health.HealthCheck
+import com.codahale.metrics.health.HealthCheckRegistry
+import com.codahale.metrics.health.HealthCheck.Result
+
+/**
+ * The mixin trait for creating a class which creates health checks.
+ *
+ * Use it as follows:
+ * {{{
+ * object Application {
+ *   // The application wide health check registry.
+ *   val healthCheckRegistry = new com.codahale.metrics.health.HealthCheckRegistry()
+ * }
+ * trait Checked extends CheckBuilder {
+ *   val healthCheckRegistry = Application.healthCheckRegistry
+ * }
+ *
+ * class Example(db: Database) extends Checked {
+ *   private[this] val databaseCheck = checks.booleanCheck("database",{ db.isConnected })
+ *
+ * }
+ * }}}
+ */
+trait CheckBuilder {
+  /**
+   * The HealthCheckRegistry where created metrics are registered.
+   */
+  val registry: HealthCheckRegistry
+
+  /**
+   * Registers a new health check for a boolean type, possibly converted implicitly.
+   *
+   * @param name  the name of the health check
+   * @param result the body of the health check
+   * @param failureMessage an optional failure message
+   */
+  def booleanCheck[A <% Boolean](name: String, result: => A, failureMessage: String = "Health check failed"): HealthCheck = {
+    val check = new BooleanHealthCheck(result, failureMessage)
+    registry.register(name, check)
+    check
+  }
+
+  /**
+   * Registers a new health check for an Either type.  Left is considered unhealthy, Right is considered healthy.
+   * If Left is of type string it will be used to override the failure message.  If Left extends Throwable,
+   * it overrides the failure message.  If Right is of type string it will override and set a healthy message.
+   * In all other cases, the type is ignored.
+   *
+   * @param name  the name of the health check
+   * @param result the body of the health check
+   * @param failureMessage an optional failure message
+   */
+  def eitherCheck[A,B](name: String, result: => Either[A,B], failureMessage: String = "Health check failed"): HealthCheck = {
+    val check = new EitherHealthCheck(result,failureMessage)
+    registry.register(name, check)
+    check
+  }
+
+}
+
+protected class BooleanHealthCheck[A <% Boolean](result : => A, failureMessage: String) extends HealthCheck {
+  protected def check: Result = result match {
+    case true => Result.healthy()
+    case _ => Result.unhealthy(failureMessage)
+  }
+}
+
+protected class EitherHealthCheck[A,B](result: => Either[A,B], failureMessage: String) extends HealthCheck {
+  protected def check: Result = result match {
+    case Right(s:String) => Result.healthy(s)
+    case Right(_) => Result.healthy()
+    case Left(s: String) => Result.unhealthy(s)
+    case Left(t: Throwable) => Result.unhealthy(t)
+    case Left(_) => Result.unhealthy(failureMessage)
+  }
+}

--- a/src/test/scala/nl/grons/metrics/scala/HealthCheckSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/HealthCheckSpec.scala
@@ -1,0 +1,139 @@
+package nl.grons.metrics.scala
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSpec
+import org.scalatest.OneInstancePerTest
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.mock.MockitoSugar
+import com.codahale.metrics.health.HealthCheckRegistry
+import com.codahale.metrics.health.HealthCheck.Result
+
+sealed trait Outcome
+case object Success extends Outcome
+case object Failure extends Outcome
+
+object HealthCheckSpec {
+
+  implicit def outcome2Boolean(outcome: Outcome) = outcome match {
+    case Success => true
+    case Failure => false
+  }
+
+}
+
+@RunWith(classOf[JUnitRunner])
+class HealthCheckSpec extends FunSpec with MockitoSugar with ShouldMatchers {
+
+  var counter = 0
+
+  def sometimesISucceed = {
+    counter += 1
+    counter % 2 == 0
+  }
+
+  def amIHealthy(health: Boolean) = {
+    () => health
+  }
+
+  def isThisAHealthyOutcome(health: Boolean):() => Outcome = health match {
+    case true => () => Success
+    case false => () => Failure
+  }
+
+  def eitherHealthyOrNot[A](health: Boolean, content: A): () => Either[A,A] = health match {
+    case true => () => Right(content)
+    case false => () => Left(content)
+  }
+
+  val testRegistry = mock[HealthCheckRegistry]
+
+  class Checked extends CheckBuilder {
+    import HealthCheckSpec._
+
+    val registry = testRegistry
+
+    def booleanChecked(name: String, failureMessage: String, healthy: Boolean) = {
+      booleanCheck(name, amIHealthy(healthy)(), failureMessage)
+    }
+
+    def implicitBooleanCheck(name: String, failureMessage: String, healthy: Boolean) = {
+      checks.booleanCheck(name, isThisAHealthyOutcome(healthy)(), failureMessage)
+    }
+
+    def sometimesSuccessfulCheck(name: String, failureMessage: String) = {
+      checks.booleanCheck(name, sometimesISucceed, failureMessage)
+    }
+
+    def eitherChecked[A](name: String, content: A, failureMessage: String, healthy: Boolean) = {
+      checks.eitherCheck(name, eitherHealthyOrNot(healthy, content)(), failureMessage)
+    }
+  }
+
+  val checks = new Checked()
+
+  describe("a boolean health check") {
+
+    it("reports healthy on true") {
+      val check = checks.booleanChecked("test", "FAIL", true)
+      check.execute() should be (Result.healthy())
+      // Should succeed every time
+      check.execute() should be (Result.healthy())
+    }
+
+    it("reports unhealthy on false") {
+      val check = checks.booleanChecked("test", "FAIL", false)
+      check.execute() should be (Result.unhealthy("FAIL"))
+      // Should fail every time
+      check.execute() should be (Result.unhealthy("FAIL"))
+    }
+
+    it("supports implicit conversion to boolean") {
+      val check = checks.implicitBooleanCheck("test", "FAIL", false)
+      check.execute() should be (Result.unhealthy("FAIL"))
+      // Should fail every time
+      check.execute() should be (Result.unhealthy("FAIL"))
+    }
+
+    it("works as expected for alternating values") {
+      val check = checks.sometimesSuccessfulCheck("test", "FAIL")
+      check.execute() should be (Result.unhealthy("FAIL"))
+      check.execute() should be (Result.healthy())
+      check.execute() should be (Result.unhealthy("FAIL"))
+      check.execute() should be (Result.healthy())
+    }
+  }
+
+  describe("an either health check") {
+
+    it("reports healthy on right") {
+      val check = checks.eitherChecked("test",(),"FAIL",true)
+      check.execute() should be (Result.healthy())
+      // Should fail every time
+      check.execute() should be (Result.healthy())
+    }
+
+    it("reports unhealthy on left") {
+      val check = checks.eitherChecked("test",(),"FAIL",false)
+      check.execute() should be (Result.unhealthy("FAIL"))
+      // Should fail every time
+      check.execute() should be (Result.unhealthy("FAIL"))
+    }
+
+    it("allows override of healthy message")  {
+      val check = checks.eitherChecked("test","HUZZAH!","FAIL",true)
+      check.execute() should be (Result.healthy("HUZZAH!"))
+      // Should fail every time
+      check.execute() should be (Result.healthy("HUZZAH!"))
+    }
+
+    it("allows override of unhealthy message") {
+      val check = checks.eitherChecked("test","BZZZZZZZT!","FAIL",false)
+      check.execute() should be (Result.unhealthy("BZZZZZZZT!"))
+      // Should fail every time
+      check.execute() should be (Result.unhealthy("BZZZZZZZT!"))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Added support for registering as health checks boolean by-name expressions as well as by-name expressions of type Either.
