### PR TITLE
Fix reference to healthCheckRegistry

### DIFF
--- a/docs/HealthCheckManual.md
+++ b/docs/HealthCheckManual.md
@@ -49,12 +49,12 @@ object YourApplication {
   /** The application wide metrics registry. */
   val metricRegistry = new com.codahale.metrics.MetricRegistry()
   /** The application wide health check registry. */
-  val healthChecksRegistry = new com.codahale.metrics.health.HealthCheckRegistry();
+  val healthCheckRegistry = new com.codahale.metrics.health.HealthCheckRegistry();
 }
 
 trait Instrumented extends InstrumentedBuilder with CheckedBuilder {
   val metricRegistry = YourApplication.metricRegistry
-  val healthCheckRegistry = Application.healthCheckRegistry
+  val healthCheckRegistry = YourApplication.healthCheckRegistry
 }
 ```
 


### PR DESCRIPTION
This just fixes typos in the documentation. 

There is another issue though:

The `Checked` trait defines `healthCheckRegistry` where it should be saying just `registry` as [CheckedBuilder#L32](https://github.com/erikvanoosten/metrics-scala/blob/master/src/main/scala/nl/grons/metrics/scala/CheckedBuilder.scala#L32) says so. But I think I would actually prefer the `CheckedBuilder` to define `healthCheckRegistry` instead of just `registry`.
