### PR TITLE
Allow non-Class-based metric naming.

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/CheckedBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/CheckedBuilder.scala
@@ -24,7 +24,7 @@ import com.codahale.metrics.health.{HealthCheck, HealthCheckRegistry}
  */
 trait CheckedBuilder {
   /** The owner of the health check. */
-  val owner: Class[_] = getClass
+  val baseName: MetricName = MetricName(getClass)
 
   /**
    * The [[com.codahale.metrics.health.HealthCheckRegistry]] where created metrics are registered.
@@ -64,7 +64,7 @@ trait CheckedBuilder {
    */
   def healthCheck(name: String, unhealthyMessage: String = "Health check failed")(checker: HealthCheckMagnet): HealthCheck = {
     val check = checker(unhealthyMessage)
-    registry.register(MetricBuilder.metricName(owner, Seq(name)), check)
+    registry.register(baseName.append(name).name, check)
     check
   }
 }

--- a/src/main/scala/nl/grons/metrics/scala/InstrumentedBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/InstrumentedBuilder.scala
@@ -41,7 +41,7 @@ import com.codahale.metrics.MetricRegistry
  * }}}
  */
 trait InstrumentedBuilder {
-  private lazy val metricBuilder = new MetricBuilder(getClass, metricRegistry)
+  private lazy val metricBuilder = new MetricBuilder(MetricName(getClass), metricRegistry)
 
   /**
    * The MetricBuilder that can be used for creating timers, counters, etc.

--- a/src/main/scala/nl/grons/metrics/scala/MetricBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/MetricBuilder.scala
@@ -22,7 +22,7 @@ import com.codahale.metrics.{Gauge => CHGauge}
 /**
  * Builds and registering metrics.
  */
-class MetricBuilder(val owner: Class[_], val registry: MetricRegistry) {
+class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
 
   /**
    * Registers a new gauge metric.
@@ -70,29 +70,5 @@ class MetricBuilder(val owner: Class[_], val registry: MetricRegistry) {
     new Timer(registry.timer(metricName(name, scope)))
 
   private[this] def metricName(name: String, scope: String = null): String =
-    MetricBuilder.metricName(owner, Seq(name, scope))
-
-}
-
-object MetricBuilder {
-  /**
-   * Create a metrics name.
-   * Unlike [[com.codahale.metrics.MetricRegistry.name()]] this version supports Scala classes
-   * such as objects and closures.
-   *
-   * @param owner the owning class
-   * @param names the parts of the metric name, any `null`s are ignored
-   * @return owner's class, name and names concatenated by periods
-   */
-  def metricName(owner: Class[_], names: Seq[String]): String = {
-    // Example weird class name: TestContext$$anonfun$2$$anonfun$apply$TestObject$2$
-    def removeScalaParts(s: String) = s.
-      replaceAllLiterally("$$anonfun", ".").
-      replaceAllLiterally("$apply", ".").
-      replaceAll("""\$\d*""", ".").
-      replaceAllLiterally(".package.", ".").
-      split('.')
-
-    (removeScalaParts(owner.getName) ++ names.filter(_ != null)).filter(_.nonEmpty).mkString(".")
-  }
+    baseName.append(name, scope).name
 }

--- a/src/main/scala/nl/grons/metrics/scala/MetricName.scala
+++ b/src/main/scala/nl/grons/metrics/scala/MetricName.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2013-2013 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.grons.metrics.scala
+
+class MetricName(val name: String) {
+  def append(names: String*): MetricName =
+    new MetricName((name.split('.') ++ names.filter(_ != null)).filter(_.nonEmpty).mkString("."))
+}
+
+object MetricName {
+  def apply(name: String, names: String*): MetricName = new MetricName(name).append(names: _*)
+
+  /**
+   * Create a metrics name.
+   * Unlike [[com.codahale.metrics.MetricRegistry.name()]] this version supports Scala classes
+   * such as objects and closures.
+   *
+   * @param owner the owning class
+   * @return owner's classname as a metric name
+   */
+  def apply(klass: Class[_]): MetricName = new MetricName(removeScalaParts(klass.getName))
+
+  // Example weird class name: TestContext$$anonfun$2$$anonfun$apply$TestObject$2$
+  private def removeScalaParts(s: String) =
+    s.replaceAllLiterally("$$anonfun", ".")
+     .replaceAllLiterally("$apply", ".")
+     .replaceAll("""\$\d*""", ".")
+     .replaceAllLiterally(".package.", ".")
+}

--- a/src/main/scala_2.10/nl/grons/metrics/scala/ActorMetrics.scala
+++ b/src/main/scala_2.10/nl/grons/metrics/scala/ActorMetrics.scala
@@ -43,7 +43,7 @@ import akka.actor.Actor
  */
 trait ReceiveCounterActor extends Actor { self: InstrumentedBuilder =>
 
-  def receiveCounterName: String = MetricBuilder.metricName(getClass, Seq("receiveCounter"))
+  def receiveCounterName: String = MetricName(getClass).append("receiveCounter").name
   lazy val counter: Counter = metrics.counter(receiveCounterName)
 
   private[this] lazy val wrapped = counter.count(super.receive)
@@ -77,7 +77,7 @@ trait ReceiveCounterActor extends Actor { self: InstrumentedBuilder =>
  */
 trait ReceiveTimerActor extends Actor { self: InstrumentedBuilder =>
 
-  def receiveTimerName: String = MetricBuilder.metricName(getClass, Seq("receiveTimer"))
+  def receiveTimerName: String = MetricName(getClass).append("receiveTimer").name
   lazy val timer: Timer = metrics.timer(receiveTimerName)
 
   private[this] lazy val wrapped = timer.timePF(super.receive)
@@ -110,7 +110,7 @@ trait ReceiveTimerActor extends Actor { self: InstrumentedBuilder =>
  */
 trait ReceiveExceptionMeterActor extends Actor { self: InstrumentedBuilder =>
 
-  def receiveExceptionMeterName: String = MetricBuilder.metricName(getClass, Seq("receiveExceptionMeter"))
+  def receiveExceptionMeterName: String = MetricName(getClass).append("receiveExceptionMeter").name
   lazy val meter: Meter = metrics.meter(receiveExceptionMeterName)
 
   private[this] lazy val wrapped = meter.exceptionMarkerPF(super.receive)

--- a/src/test/scala/nl/grons/metrics/scala/MetricBuilderSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/MetricBuilderSpec.scala
@@ -55,30 +55,30 @@ class MetricBuilderSpec extends FunSpec with MockitoSugar with ShouldMatchers wi
     def histogramPlusOne() { histogram += 1 }
   }
 
-  describe("Metrics name builder") {
+  describe("MetricName") {
     it("concatenates names with a period as separator") {
-      MetricBuilder.metricName(classOf[MetricBuilder], Seq("part1", "part2")) should equal ("nl.grons.metrics.scala.MetricBuilder.part1.part2")
+      MetricName(classOf[MetricBuilder]).append("part1", "part2").name should equal ("nl.grons.metrics.scala.MetricBuilder.part1.part2")
     }
 
     it("skips nulls") {
-      MetricBuilder.metricName(classOf[MetricBuilder], Seq("part1", null)) should equal ("nl.grons.metrics.scala.MetricBuilder.part1")
+      MetricName(classOf[MetricBuilder]).append("part1", null).name should equal ("nl.grons.metrics.scala.MetricBuilder.part1")
     }
 
     it("supports closures") {
-      val foo: String => Class[_] = s => this.getClass
-      MetricBuilder.metricName(foo(""), Seq("part1")) should equal ("nl.grons.metrics.scala.MetricBuilderSpec.part1")
+      val foo: String => MetricName = s => MetricName(this.getClass)
+      foo("").append("part1").name should equal ("nl.grons.metrics.scala.MetricBuilderSpec.part1")
     }
 
     it("supports objects") {
-      MetricBuilder.metricName(MetricBuilderSpec.ref, Seq("part1")) should equal ("nl.grons.metrics.scala.MetricBuilderSpec.part1")
+      MetricBuilderSpec.ref.append("part1").name should equal ("nl.grons.metrics.scala.MetricBuilderSpec.part1")
     }
 
     it("supports nested objects") {
-      MetricBuilder.metricName(MetricBuilderSpec.nestedRef, Seq("part1")) should equal ("nl.grons.metrics.scala.MetricBuilderSpec.Nested.part1")
+      MetricBuilderSpec.nestedRef.append("part1").name should equal ("nl.grons.metrics.scala.MetricBuilderSpec.Nested.part1")
     }
 
     it("supports packages") {
-        MetricBuilder.metricName(nl.grons.metrics.scala.ref, Seq("part1")) should equal ("nl.grons.metrics.scala.part1")
+        nl.grons.metrics.scala.ref.append("part1").name should equal ("nl.grons.metrics.scala.part1")
     }
   }
 
@@ -115,8 +115,8 @@ class MetricBuilderSpec extends FunSpec with MockitoSugar with ShouldMatchers wi
 
 object MetricBuilderSpec {
   object Nested {
-    val ref: Class[_] = this.getClass
+    val ref: MetricName = MetricName(this.getClass)
   }
-  private val ref: Class[_] = this.getClass
-  private val nestedRef: Class[_] = Nested.ref
+  private val ref: MetricName = MetricName(this.getClass)
+  private val nestedRef: MetricName = Nested.ref
 }

--- a/src/test/scala/nl/grons/metrics/scala/package.scala
+++ b/src/test/scala/nl/grons/metrics/scala/package.scala
@@ -20,5 +20,5 @@ package nl.grons.metrics
  * Used in [[nl.grons.metrics.scala.MetricBuilderSpec]].
  */
 package object scala {
-  val ref: Class[_] = this.getClass
+  val ref: MetricName = MetricName(this.getClass)
 }


### PR DESCRIPTION
Create MetricsBuilder with MetricName rather than Class[_].
MetricName.apply(Class[_]) for standard naming.
