### PR TITLE
Address unintuitive health check boolean by-value interplay with implicit

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/CheckedBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/CheckedBuilder.scala
@@ -87,10 +87,22 @@ object HealthCheckMagnet {
   /**
    * Magnet for checkers returning a [[scala.Boolean]] (possibly implicitly converted).
    */
+  @deprecated("This method may cause unexpected results due to the interaction between implicit resolution and by-value methods.  Please use fromBooleanFunctionCheck instead.","3.1.2")
   implicit def fromBooleanCheck[A <% Boolean](checker: => A) = new HealthCheckMagnet {
     def apply(unhealthyMessage: String) = new HealthCheck() {
       protected def check: Result =
         if (checker) Result.healthy()
+        else Result.unhealthy(unhealthyMessage)
+    }
+  }
+
+  /**
+   * Magnet for checker functions returning a [[scala.Boolean]] (possibly implicitly converted).
+   */
+  implicit def fromBooleanFunctionCheck[A <% Boolean](checker: () => A) = new HealthCheckMagnet {
+    def apply(unhealthyMessage: String) = new HealthCheck() {
+      protected def check: Result =
+        if (checker()) Result.healthy()
         else Result.unhealthy(unhealthyMessage)
     }
   }


### PR DESCRIPTION
- Deprecates boolean by-value used with implicit
- Adds & recommends new boolean function
- Fixes #42

Note: `@deprecation` tag expects fix version # to be `3.1.2` - please change as necessary @erikvanoosten
