### PR TITLE
Invoke the argument to timing only once.

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/FutureMetrics.scala
+++ b/src/main/scala/nl/grons/metrics/scala/FutureMetrics.scala
@@ -94,7 +94,8 @@ trait FutureMetrics { self: InstrumentedBuilder =>
   def timing[A](metricName: String)(future: => Future[A])(implicit context: ExecutionContext): Future[A] = {
     val timer = metrics.timer(metricName)
     val ctx = timer.timerContext
-    future.onComplete(_ => ctx.stop())
-    future
+    val f = future
+    f.onComplete(_ => ctx.stop())
+    f
   }
 }

--- a/src/test/scala/nl/grons/metrics/scala/FutureMetricsSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/FutureMetricsSpec.scala
@@ -62,13 +62,16 @@ class FutureMetricsSpec extends FunSpec with OneInstancePerTest with FutureMetri
 
     it("should attach an onComplete listener") {
       val p = Promise[String]()
+      var invocationCount = 0
       val f = timing("test") {
+        invocationCount += 1
         p.future
       }
       p.success("test")
       val result = Await.result(f, 50.millis)
       result should be ("test")
       verify(mockTimerContext).stop()
+      invocationCount should be (1)
     }
   }
 


### PR DESCRIPTION
The argument to a pass-by-name parameter is inserted each type the
parameter name appears in the function body. Since `future` appears
twice, it executes twice.

Assigning the parameter to variable causes the argument to be executed
only once.
