### PR TITLE
val misnamed on docs

### DIFF
--- a/docs/HealthCheckManual.md
+++ b/docs/HealthCheckManual.md
@@ -12,7 +12,7 @@ object YourApplication {
   val healthChecksRegistry = new com.codahale.metrics.health.HealthCheckRegistry();
 }
 trait Checked extends nl.grons.metrics.scala.CheckedBuilder {
-  val healthCheckRegistry = Application.healthCheckRegistry
+  val registry = Application.healthCheckRegistry
 }
 ```
 
@@ -106,7 +106,7 @@ object YourApplication {
 trait Instrumented extends InstrumentedBuilder with CheckedBuilder {
   override lazy val metricBaseName = MetricName(getClass) // Required with 3.1.0, optional since 3.1.1.
   val metricRegistry = YourApplication.metricRegistry
-  val healthCheckRegistry = YourApplication.healthCheckRegistry
+  val registry = YourApplication.healthCheckRegistry
 }
 ```
 


### PR DESCRIPTION
The val should be just `registry` as stated at https://github.com/erikvanoosten/metrics-scala/blob/master/src/main/scala/nl/grons/metrics/scala/CheckedBuilder.scala#L30 rather than `healthCheckRegistry`. I could submit a pull request to do it the other way round and change the code but it will break backward compatibility