### PR TITLE
Capture an entire by-name expression

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/ByName.scala
+++ b/src/main/scala/nl/grons/metrics/scala/ByName.scala
@@ -1,0 +1,33 @@
+package nl.grons.metrics.scala
+
+/**
+ * Provides a wrapper for by-name expressions with the intent that they can become eligible for
+ * implicit conversions and implicit resolution.
+ *
+ * @param expression A by-name parameter that will yield a result of type `T` when evaluated.
+ * @tparam T Result type of the evaluated `expression`.
+ */
+final class ByName[+T](expression: => T) extends (() => T) {
+  /**
+   * Evaluates the given `expression` every time <em>without</em> memoizing the result.
+   *
+   * @return Result of type `T` when evaluating the provided `expression`.
+   */
+  def apply(): T = expression
+
+  /**
+   * Lazily maps the given expression of type `T` to type `U`.
+   */
+  def map[U](fn: T => U): ByName[U] =
+    ByName[U](fn(expression))
+}
+
+object ByName {
+  import scala.language.implicitConversions
+
+  /**
+   * Implicitly converts a by-name `expression` of type `T` into an instance of [[nl.grons.metrics.scala.ByName]].
+   */
+  implicit def apply[T](expression: => T): ByName[T] =
+    new ByName(expression)
+}


### PR DESCRIPTION
`HealthCheckMagnet.fromTryChecker()` (e.g.) converts a by-name `Try` into an instance of `HealthCheckMagnet`. This is so it can be made available in `CheckedBuilder.healthCheck()`. Unfortunately (IMO), when you have a multi-line expression you want to provide to `healthCheck()`, it will apply the implicit conversion from `Try` to `HealthCheckMagnet` only on the result of the expression and not the entire thing. I'd like the ability to capture the entire expression without needing to wrap it in a `Try` or `Either`. It's possible I may not want a `Try` but to instead use a simpler check like the `Boolean` one. The `ByName` class allows us to (when we want to) capture the entire expression instead of just the result. A simple example would be:

```scala
healthCheck("foo") {
  println("FOO")
  true
}
```

Here the health check is side-effecting (not normally a desirable thing, but sometimes a necessity). However with the current implementation the side effect will be evaluated once (when the implicit conversion to the magnet occurs) and then never again. This can result in a mismatch between the expected behavior and the observed behavior. This PR eliminates that mismatch by capturing the entire expression.