### PR TITLE
Add helper to Counter to track concurrent executions.

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/Counter.scala
+++ b/src/main/scala/nl/grons/metrics/scala/Counter.scala
@@ -36,9 +36,9 @@ class Counter(metric: DropwizardCounter) {
      }
 
   /**
-   * Runs f and counts concurrent executions of concurrentCount
+   * Runs f and counts concurrent executions of countConcurrencyOf
    */
-  def concurrentCount[A](f: => A): A = {
+  def countConcurrencyOf[A](f: => A): A = {
     metric.inc(1)
     try {
       f

--- a/src/main/scala/nl/grons/metrics/scala/Counter.scala
+++ b/src/main/scala/nl/grons/metrics/scala/Counter.scala
@@ -22,7 +22,6 @@ import com.codahale.metrics.{Counter => DropwizardCounter}
  * A Scala facade class for [[DropwizardCounter]].
  */
 class Counter(metric: DropwizardCounter) {
-
   /**
    * Wraps partial function pf, incrementing counter once for every execution
    */
@@ -35,6 +34,18 @@ class Counter(metric: DropwizardCounter) {
 
        def isDefinedAt(a: A) = pf.isDefinedAt(a)
      }
+
+  /**
+   * Runs f and counts concurrent executions of concurrentCount
+   */
+  def concurrentCount[A](f: => A): A = {
+    metric.inc(1)
+    try {
+      f
+    } finally {
+      metric.dec(1)
+    }
+  }
 
   /**
    * Increments the counter by delta.

--- a/src/test/scala/nl/grons/metrics/scala/CounterSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/CounterSpec.scala
@@ -59,7 +59,7 @@ class CounterSpec extends FunSpec with OneInstancePerTest {
 
     it("should increment and decrement a counter upon execution of a function") {
       def x = 123
-      val result = counter.concurrentCount(x)
+      val result = counter.countConcurrencyOf(x)
       verify(metric).inc(1)
       verify(metric).dec(1)
       result should be (x)

--- a/src/test/scala/nl/grons/metrics/scala/CounterSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/CounterSpec.scala
@@ -56,5 +56,13 @@ class CounterSpec extends FunSpec with OneInstancePerTest {
       verify(metric).inc(1)
       wrapped.isDefinedAt("x") should be (false)
     }
+
+    it("should increment and decrement a counter upon execution of a function") {
+      def x = 123
+      val result = counter.concurrentCount(x)
+      verify(metric).inc(1)
+      verify(metric).dec(1)
+      result should be (x)
+    }
   }
 }


### PR DESCRIPTION
A common pattern we have is:

    counter.inc(1)
    try {
      expensiveWork()
    } finally {
      counter.dec(1)
    }

This lets us see how many times we're calling expensiveWork
concurrently.

Thanks @fedeoasi for the original idea and implementation.