### PR TITLE
FutureMetrics object

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/FutureMetrics.scala
+++ b/src/main/scala/nl/grons/metrics/scala/FutureMetrics.scala
@@ -99,3 +99,20 @@ trait FutureMetrics { self: InstrumentedBuilder =>
     f
   }
 }
+
+object FutureMetrics {
+  def timed[A](metricName: String)(action: => A)
+              (implicit ec: ExecutionContext, metrics: MetricBuilder): Future[A] = {
+    val timer = metrics.timer(metricName)
+    Future(timer.time(action))
+  }
+
+  def timing[A](metricName: String)(future: => Future[A])
+               (implicit ec: ExecutionContext, metrics: MetricBuilder): Future[A] = {
+    val timer = metrics.timer(metricName)
+    val ctx = timer.timerContext()
+    val f = future
+    f.onComplete(_ => ctx.stop())
+    f
+  }
+}


### PR DESCRIPTION
In some cases it's undesirable to extend the `FutureMetrics` trait, for example when we don't want to bring `timing` and `timed` method names to the scope of the class/trait we're extending. In such an object that you could import is more desirable.

Here is a quick sketch of such object. @erikvanoosten what do you think?

Please don't treat this as a final PR, I know that there is code duplication, it's missing tests and documentation, but I'd like to get your feedback first. :-)