### PR TITLE
Gauge.unregister for actors

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/Gauge.scala
+++ b/src/main/scala/nl/grons/metrics/scala/Gauge.scala
@@ -16,10 +16,10 @@
 
 package nl.grons.metrics.scala
 
-import com.codahale.metrics.{Gauge => DropwizardGauge, Metric => DropwizardMetric, MetricFilter, MetricRegistry}
+import com.codahale.metrics.{Gauge => DropwizardGauge}
 
 object Gauge {
-  def apply[A](registry: MetricRegistry)(f: => A) = new Gauge[A](registry, new DropwizardGauge[A] {
+  def apply[A](f: => A) = new Gauge[A](new DropwizardGauge[A] {
     def getValue = f
   })
 }
@@ -27,19 +27,11 @@ object Gauge {
 /**
  * A Scala facade class for [[DropwizardGauge]].
  */
-class Gauge[T](registry: MetricRegistry, metric: DropwizardGauge[T]) {
+class Gauge[T](metric: DropwizardGauge[T]) {
 
   /**
    * The current value.
    */
   def value: T = metric.getValue
 
-  /**
-   * Unregisters this Gauge from the metric registry.
-   */
-  def unregister(): Unit = {
-    registry.removeMatching(new MetricFilter {
-      override def matches(name: String, dwMetric: DropwizardMetric): Boolean = metric eq dwMetric
-    })
-  }
 }

--- a/src/main/scala/nl/grons/metrics/scala/MetricBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/MetricBuilder.scala
@@ -32,7 +32,7 @@ class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
    * @param scope the scope of the gauge or null for no scope
    */
   def gauge[A](name: String, scope: String = null)(f: => A): Gauge[A] =
-    new Gauge[A](registry.register(metricNameFor(name, scope), new DropwizardGauge[A] { def getValue: A = f }))
+    new Gauge[A](registry, registry.register(metricNameFor(name, scope), new DropwizardGauge[A] { def getValue: A = f }))
 
   /**
    * Registers a new gauge metric that caches its value for a given duration.
@@ -42,7 +42,7 @@ class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
    * @param scope the scope of the gauge or null for no scope
    */
   def cachedGauge[A](name: String, timeout: FiniteDuration, scope: String = null)(f: => A): Gauge[A] =
-    new Gauge[A](registry.register(metricNameFor(name, scope), new DropwizardCachedGauge[A](timeout.length, timeout.unit) { def loadValue: A = f }))
+    new Gauge[A](registry, registry.register(metricNameFor(name, scope), new DropwizardCachedGauge[A](timeout.length, timeout.unit) { def loadValue: A = f }))
 
   /**
    * Creates a new counter metric.

--- a/src/main/scala/nl/grons/metrics/scala/MetricBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/MetricBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Erik van Oosten
+ * Copyright (c) 2013-2016 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,19 @@
 
 package nl.grons.metrics.scala
 
-import com.codahale.metrics.MetricRegistry
-import com.codahale.metrics.{Gauge => DropwizardGauge, CachedGauge => DropwizardCachedGauge}
-import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.atomic.AtomicReference
+
+import com.codahale.metrics.{CachedGauge => DropwizardCachedGauge, Gauge => DropwizardGauge, Metric, MetricFilter, MetricRegistry}
+import nl.grons.metrics.scala.MoreImplicits.RichAtomicReference
+
+import _root_.scala.concurrent.duration.FiniteDuration
 
 /**
  * Builds and registering metrics.
  */
 class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
+
+  private[this] val gauges: AtomicReference[Seq[DropwizardGauge[_]]] = new AtomicReference(Seq.empty)
 
   /**
    * Registers a new gauge metric.
@@ -31,8 +36,9 @@ class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
    * @param name the name of the gauge
    * @param scope the scope of the gauge or null for no scope
    */
-  def gauge[A](name: String, scope: String = null)(f: => A): Gauge[A] =
-    new Gauge[A](registry, registry.register(metricNameFor(name, scope), new DropwizardGauge[A] { def getValue: A = f }))
+  def gauge[A](name: String, scope: String = null)(f: => A): Gauge[A] = {
+    wrapDwGauge(metricNameFor(name, scope), new DropwizardGauge[A] { def getValue: A = f })
+  }
 
   /**
    * Registers a new gauge metric that caches its value for a given duration.
@@ -41,8 +47,15 @@ class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
    * @param timeout the timeout
    * @param scope the scope of the gauge or null for no scope
    */
-  def cachedGauge[A](name: String, timeout: FiniteDuration, scope: String = null)(f: => A): Gauge[A] =
-    new Gauge[A](registry, registry.register(metricNameFor(name, scope), new DropwizardCachedGauge[A](timeout.length, timeout.unit) { def loadValue: A = f }))
+  def cachedGauge[A](name: String, timeout: FiniteDuration, scope: String = null)(f: => A): Gauge[A] = {
+    wrapDwGauge(metricNameFor(name, scope), new DropwizardCachedGauge[A](timeout.length, timeout.unit) { def loadValue: A = f })
+  }
+
+  private def wrapDwGauge[A](name: String, dwGauge: DropwizardGauge[A]): Gauge[A] = {
+    registry.register(name, dwGauge)
+    gauges.getAndTransform(_ :+ dwGauge)
+    new Gauge[A](dwGauge)
+  }
 
   /**
    * Creates a new counter metric.
@@ -79,6 +92,17 @@ class MetricBuilder(val baseName: MetricName, val registry: MetricRegistry) {
    */
   def timer(name: String, scope: String = null): Timer =
     new Timer(registry.timer(metricNameFor(name, scope)))
+
+  /**
+   * Unregisters all gauges that were created through this builder.
+   */
+  def unregisterGauges(): Unit = {
+    val toUnregister = gauges.getAndTransform(_ => Seq.empty)
+    registry.removeMatching(new MetricFilter {
+      override def matches(name: String, metric: Metric): Boolean =
+        metric.isInstanceOf[DropwizardGauge[_]] && toUnregister.contains(metric)
+    })
+  }
 
   protected def metricNameFor(name: String, scope: String = null): String =
     baseName.append(name, scope).name

--- a/src/main/scala/nl/grons/metrics/scala/MoreImplicits.scala
+++ b/src/main/scala/nl/grons/metrics/scala/MoreImplicits.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2013-2016 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.grons.metrics.scala
+
+import java.util.concurrent.atomic.AtomicReference
+
+import _root_.scala.annotation.tailrec
+
+private[scala] object MoreImplicits {
+
+  /**
+    * Extends [[AtomicReference]] with `getAndTransform`.
+    */
+  private[scala] implicit class RichAtomicReference[A](val atomicReference: AtomicReference[A]) {
+    /**
+      * Invokes `transformation` with the current value and then sets the result as the new value.
+      * When another concurrent change was detected, the operation is retried. The retry is repeated
+      * as often as is necessary.
+      *
+      * @param transformation the transformation function
+      * @return the old value
+      */
+    @tailrec
+    final def getAndTransform(transformation: A => A): A = {
+      val oldValue = atomicReference.get()
+      val update = transformation(oldValue)
+
+      if (!atomicReference.compareAndSet(oldValue, update))
+        this.getAndTransform(transformation)
+      else
+        oldValue
+    }
+  }
+
+}

--- a/src/test/akka/nl/grons/metrics/scala/ActorGaugeLifecycleSpec.scala
+++ b/src/test/akka/nl/grons/metrics/scala/ActorGaugeLifecycleSpec.scala
@@ -41,7 +41,7 @@ object ActorGaugeLifecycleSpec {
 
     var counter = 0
 
-    metrics.gauge("counter") {
+    metrics.gauge("counter-gauge") {
       counter
     }
 

--- a/src/test/akka/nl/grons/metrics/scala/ActorGaugeLifecycleSpec.scala
+++ b/src/test/akka/nl/grons/metrics/scala/ActorGaugeLifecycleSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2013-2016 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.grons.metrics.scala
+
+import akka.actor.{Actor, ActorSystem, Props}
+import akka.testkit._
+import com.codahale.metrics._
+import org.junit.runner.RunWith
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+
+import scala.concurrent.Promise
+
+object ActorGaugeLifecycleSpec {
+
+  object Application {
+    // The application wide metrics registry.
+    val metricRegistry = new com.codahale.metrics.MetricRegistry()
+  }
+
+  trait Instrumented extends InstrumentedBuilder {
+    val metricRegistry = Application.metricRegistry
+  }
+
+  class ExampleActor(restarted: Promise[Boolean]) extends Actor with Instrumented with ActorLifecycleMetricsLink {
+
+    var counter = 0
+
+    metrics.gauge("counter") {
+      counter
+    }
+
+    override def preRestart(reason: Throwable, message: Option[Any]) = {
+      self ! 'prerestart
+      super.preRestart(reason, message)
+    }
+
+    def receive = {
+      case 'increment =>
+        counter += 1
+      case 'get =>
+        sender() ! counter
+      case 'error =>
+        throw new RuntimeException("BOOM!")
+      case 'prerestart =>
+        restarted.success(true)
+    }
+
+  }
+}
+
+@RunWith(classOf[JUnitRunner])
+class ActorGaugeLifecycleSpec extends TestKit(ActorSystem("lifecycle_spec")) with FunSpecLike with ImplicitSender with Matchers with ScalaFutures with BeforeAndAfterAll {
+  import ActorGaugeLifecycleSpec._
+  import collection.JavaConverters._
+
+  case class NameFilter(prefix: String) extends MetricFilter {
+    override def matches(name: String, metric: Metric): Boolean = name.startsWith(prefix)
+  }
+
+  def report = {
+    Application.metricRegistry
+      .getGauges(NameFilter("nl.grons.metrics.scala")).asScala
+      .headOption
+      .map {case (_,g) => g.getValue}
+  }
+
+  describe("an actor with gauges needing lifecycle management") {
+    val restartedPromise = Promise[Boolean]()
+    val ar = system.actorOf(Props(new ExampleActor(restartedPromise)))
+
+    it("correctly builds a gauge that reports the correct value") {
+      ar ! 'increment
+      ar ! 'increment
+      ar ! 'increment
+      ar ! 'get
+      expectMsg(3)
+      report shouldBe Some(3)
+    }
+
+    it("rebuilds the gauge on actor restart") {
+      ar ! 'increment
+      ar ! 'increment
+      ar ! 'error
+      ar ! 'increment
+      ar ! 'get
+      expectMsg(1)
+      whenReady(restartedPromise.future)(_ shouldBe true)
+      report shouldBe Some(1)
+    }
+  }
+
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+}

--- a/src/test/akka/nl/grons/metrics/scala/ActorGaugeLifecycleSpec.scala
+++ b/src/test/akka/nl/grons/metrics/scala/ActorGaugeLifecycleSpec.scala
@@ -28,13 +28,10 @@ import scala.concurrent.Promise
 
 object ActorGaugeLifecycleSpec {
 
-  object Application {
-    // The application wide metrics registry.
-    val metricRegistry = new com.codahale.metrics.MetricRegistry()
-  }
+  val MetricRegistry = new com.codahale.metrics.MetricRegistry()
 
   trait Instrumented extends InstrumentedBuilder {
-    val metricRegistry = Application.metricRegistry
+    val metricRegistry = MetricRegistry
   }
 
   class ExampleActor(restarted: Promise[Boolean]) extends Actor with Instrumented with ActorLifecycleMetricsLink {
@@ -74,7 +71,7 @@ class ActorGaugeLifecycleSpec extends TestKit(ActorSystem("lifecycle_spec")) wit
   }
 
   def report = {
-    Application.metricRegistry
+    MetricRegistry
       .getGauges(NameFilter("nl.grons.metrics.scala")).asScala
       .headOption
       .map {case (_,g) => g.getValue}

--- a/src/test/scala/nl/grons/metrics/scala/GaugeSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/GaugeSpec.scala
@@ -16,9 +16,7 @@
 
 package nl.grons.metrics.scala
 
-import com.codahale.metrics.MetricFilter
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.{when, verify}
+import org.mockito.Mockito.when
 import org.scalatest.OneInstancePerTest
 import org.scalatest.Matchers._
 import org.scalatest.mock.MockitoSugar._
@@ -30,28 +28,18 @@ import org.scalatest.junit.JUnitRunner
 class GaugeSpec extends FunSpec with OneInstancePerTest {
   describe("A gauge") {
     val metric = mock[com.codahale.metrics.Gauge[Int]]
-    val repository = mock[com.codahale.metrics.MetricRegistry]
-    val gauge = new Gauge(repository, metric)
+    val gauge = new Gauge(metric)
 
     it("invokes underlying function for sugar factory") {
-      val sugared = Gauge(repository)({ 1 })
-      
+      val sugared = Gauge({ 1 })
+
       sugared.value should equal (1)
     }
 
     it("invokes getValue on underlying gauge") {
       when(metric.getValue).thenReturn(1)
-      
+
       gauge.value should equal (1)
-    }
-
-    it("unregisters the underlying gauge") {
-      gauge.unregister()
-
-      val metricFilterCaptor = ArgumentCaptor.forClass(classOf[MetricFilter])
-      verify(repository).removeMatching(metricFilterCaptor.capture)
-      metricFilterCaptor.getValue.matches("anyString", metric) should equal (true)
-      metricFilterCaptor.getValue.matches("anyString", mock[com.codahale.metrics.Gauge[Int]]) should equal (false)
     }
   }
 }


### PR DESCRIPTION
Added `Gauge.unregister`.

Trait `ActorLifecycleMetricsLink` to automatically unregister gauges from restarting actors (#69).
Spec based on #70 from @scullxbones.