### PR TITLE
timeFuture should time a closure which errors

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/Timer.scala
+++ b/src/main/scala/nl/grons/metrics/scala/Timer.scala
@@ -88,7 +88,13 @@ class Timer(private[scala] val metric: DropwizardTimer) {
     */
   def timeFuture[A](future: => Future[A])(implicit context: ExecutionContext): Future[A] = {
     val ctx = metric.time()
-    val f = future
+    val f = try {
+      future
+    } catch {
+      case ex: Throwable =>
+        ctx.stop()
+        throw ex
+    }
     f.onComplete(_ => ctx.stop())
     f
   }

--- a/src/test/scala/nl/grons/metrics/scala/TimerSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/TimerSpec.scala
@@ -79,6 +79,18 @@ class TimerSpec extends FunSpec with OneInstancePerTest {
       verify(context).stop()
     }
 
+    it("should measure a future closure which errors") {
+      import ExecutionContext.Implicits.global
+      val error = new Exception
+      val caught = intercept[Exception] {
+        timer.timeFuture(throw error)
+      }
+      caught should equal (error)
+
+      verify(metric).time()
+      verify(context).stop()
+    }
+
     it("correctly infers the type") {
       val someString = "someString"
       val timed = timer.time(myFunc(someString))


### PR DESCRIPTION
For consistency with the other `time*` methods, `timeFuture` should call `stop` on the timing context even if the closure producing the future throws an exception.