### PR TITLE
Add DefaultInstrumented Trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ class Example(db: Database) extends Instrumented {
 }
 ```
 
+If you are working on a Dropwizard 1.0.0+ application, you can use the provided `DefaultInstrumented` rather than building your own `Instrumented` trait. `DefaultInstrumented` discovers the Dropwizard app's registry via `com.codahale.metrics.SharedMetricRegistries`.
+
 For more detailed information see the [manual](docs/Manual.md). For more information on Metrics-core 3.x, please see the [documentation](https://dropwizard.github.io/metrics/3.1.0/).
 
 See the [change log](CHANGELOG.md) for API changes compared to the 2.x versions.

--- a/src/main/scala/nl/grons/metrics/scala/DefaultInstrumented.scala
+++ b/src/main/scala/nl/grons/metrics/scala/DefaultInstrumented.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.grons.metrics.scala
+
+import com.codahale.metrics.SharedMetricRegistries
+
+/**
+  * A mixin trait for creating a class that publishes metrics to the "default" registry.
+  *
+  * This is a useful default for Dropwizard 1.0.0+ applications where
+  * the Dropwizard environment publishes its built-in metrics registry as "default".
+  */
+
+trait DefaultInstrumented extends InstrumentedBuilder {
+  if (!SharedMetricRegistries.names().contains("default")) {
+    throw new IllegalStateException("No registry named \"default\" found in SharedMetricRegistries")
+  }
+  val metricRegistry = SharedMetricRegistries.getOrCreate("default")
+}

--- a/src/test/scala/nl/grons/metrics/scala/DefaultInstrumentedSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/DefaultInstrumentedSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.grons.metrics.scala
+
+import com.codahale.metrics.SharedMetricRegistries
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfter, FunSpec}
+import org.scalatest.Matchers._
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class DefaultInstrumentedSpec extends FunSpec with BeforeAndAfter {
+
+  before {
+    SharedMetricRegistries.clear()
+  }
+
+  describe("DefaultInstrumented") {
+    it("throws if no default registry exists on construction") {
+      intercept[IllegalStateException] {
+        new DefaultInstrumented {}
+      }
+    }
+    it("has the expected metricRegistry") {
+      val defaultRegistry = SharedMetricRegistries.getOrCreate("default")
+      val instrumented = new DefaultInstrumented {}
+      instrumented.metricRegistry should be theSameInstanceAs defaultRegistry
+    }
+  }
+
+}


### PR DESCRIPTION
Addresses #79 

My biggest question is whether `DefaultInstrumented` is the right name here. We could just call it `Instrumented` so that usage looks exactly the same as if you create your own, but that could cause some confusion.

Another possible name would be `DropwizardInstrumented`.