### PR TITLE
No exceptions during metric creation

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/HdrMetricBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/HdrMetricBuilder.scala
@@ -63,18 +63,18 @@ class HdrMetricBuilder(
   ): M = {
     val metricName = metricNameFor(name, scope)
     val histogram = metricFactory(createHdrReservoir())
-    try {
+
+    if (registry.getNames.contains(metricName)) {
+      val existingMetric = registry.getMetrics.get(metricName)
+      if (!classTag[M].runtimeClass.isInstance(existingMetric)) {
+        val existingMetricTye = existingMetric.getClass.getSimpleName
+        val expectedMetricType = classTag[M].runtimeClass.getSimpleName
+        throw new IllegalArgumentException(
+          s"Already existing metric '$metricName' is of type $existingMetricTye, expected a $expectedMetricType")
+      }
+      existingMetric.asInstanceOf[M]
+    } else {
       registry.register(metricName, histogram)
-    } catch {
-      case e: IllegalArgumentException =>
-        val existingMetric = registry.getMetrics.get(metricName)
-        if (!classTag[M].runtimeClass.isInstance(existingMetric)) {
-          val existingMetricTye = existingMetric.getClass.getSimpleName
-          val expectedMetricType = classTag[M].runtimeClass.getSimpleName
-          throw new IllegalArgumentException(
-            s"Already existing metric '$metricName' is of type $existingMetricTye, expected a $expectedMetricType")
-        }
-        existingMetric.asInstanceOf[M]
     }
   }
 


### PR DESCRIPTION
Our metrics collection use case involves creating metrics dynamically
and in different scopes. We noticed that one of the prime contributors
to thrown exceptions was the `HdrMetricBuilder`. By trying to register
the metric again the error case is only catched with an exception which
does hit our performance to some degree.

In order to remove this exception based error handling this change first
checks whether the metric registry already contains the metric
explicitly. If it does, the metric is only returned at this point. If
not, it is being safely created.

/cc @otrosien, who identified this actually