### PR TITLE
Fixes race condition in HdrMetricBuilder.createOrGetMetric

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/HdrMetricBuilder.scala
+++ b/src/main/scala/nl/grons/metrics/scala/HdrMetricBuilder.scala
@@ -64,18 +64,22 @@ class HdrMetricBuilder(
     val metricName = metricNameFor(name, scope)
     val histogram = metricFactory(createHdrReservoir())
 
-    if (registry.getNames.contains(metricName)) {
+    def getMetricFromRegistryByName(metricName: String) = {
       val existingMetric = registry.getMetrics.get(metricName)
       if (!classTag[M].runtimeClass.isInstance(existingMetric)) {
-        val existingMetricTye = existingMetric.getClass.getSimpleName
+        val existingMetricType = existingMetric.getClass.getSimpleName
         val expectedMetricType = classTag[M].runtimeClass.getSimpleName
-        throw new IllegalArgumentException(
-          s"Already existing metric '$metricName' is of type $existingMetricTye, expected a $expectedMetricType")
+        throw new IllegalArgumentException(s"Already existing metric '$metricName' is of type $existingMetricType, expected a $expectedMetricType")
       }
       existingMetric.asInstanceOf[M]
-    } else {
-      registry.register(metricName, histogram)
     }
+
+    if (registry.getNames.contains(metricName))
+      getMetricFromRegistryByName(metricName)
+    else // 'register' throws if the metric already exist, in that case catch the error and get the metrics from the registry manually.
+      try { registry.register(metricName, histogram)}
+      catch { case _: IllegalArgumentException => getMetricFromRegistryByName(metricName) }
+
   }
 
   private def createHdrReservoir(): Reservoir =


### PR DESCRIPTION
The pull request https://github.com/erikvanoosten/metrics-scala/pull/90 introduced an optimisation in the metric creation process.
Instead of relying on an exception based flow, the function  would look ahead in the metric registry to determine wether the metric already exists.

Sadly this introduced a race condition in the case of a metric created concurrently, several threads can pass through the 'registry.getNames.contains(metricName)'
at the same time and hit 'registry.register'.

Without catching block, the exception 'java.lang.IllegalArgumentException: A metric named xxxx already exists' would blow up the current thread.

This PR keeps the optimisation but reintroduces the try/catch block guarding us from this race condition.