### PR TITLE
Simplified `HdrMetricBuilder` by using existing functionality from `metrics-core`

### DIFF
--- a/src/main/scala/nl/grons/metrics/scala/SimpleMetricSupplier.scala
+++ b/src/main/scala/nl/grons/metrics/scala/SimpleMetricSupplier.scala
@@ -1,0 +1,14 @@
+package nl.grons.metrics.scala
+
+import com.codahale.metrics.Metric
+import com.codahale.metrics.MetricRegistry.MetricSupplier
+
+class SimpleMetricSupplier[M <: Metric](supplierFn: () ⇒ M) extends MetricSupplier[M] {
+  override def newMetric(): M = supplierFn()
+}
+
+object SimpleMetricSupplier {
+  def apply[M <: Metric](supplierFn: ⇒ M) =
+    new SimpleMetricSupplier[M](() ⇒ supplierFn)
+}
+

--- a/src/test/scala/nl/grons/metrics/scala/HdrMetricBuilderSpec.scala
+++ b/src/test/scala/nl/grons/metrics/scala/HdrMetricBuilderSpec.scala
@@ -108,7 +108,7 @@ class HdrMetricBuilderSpec extends AsyncFunSpec with OneInstancePerTest with Ins
     it ("gives IllegalArgumentException when second creation is of different type") {
       underTest.createTimer("test.metric")
       val thrown = the [IllegalArgumentException] thrownBy underTest.createHistogram("test.metric")
-      thrown.getMessage should equal ("Already existing metric 'nl.grons.metrics.scala.HdrMetricBuilderSpec.UnderTest.test.metric' is of type Timer, expected a Histogram")
+      thrown.getMessage should equal ("nl.grons.metrics.scala.HdrMetricBuilderSpec.UnderTest.test.metric is already used for a different type of metric")
     }
 
     it("defines a timer with non-resetting reservoir") {


### PR DESCRIPTION
This is relatively new functionality and was introduced about 7 month ago:

https://github.com/dropwizard/metrics/pull/1023

Moreover, `registry.getNames.contains(metricName)` was quite inefficient since it makes a copy of the set every single time:

```java
    public SortedSet<String> getNames() {
        return Collections.unmodifiableSortedSet(new TreeSet<String>(metrics.keySet()));
    }
```

Kudos to @agourlay for this discovery