### PR TITLE
Fix links to Dropwizard Metrics documentation.

### DIFF
--- a/docs/AvailableVersions.md
+++ b/docs/AvailableVersions.md
@@ -977,7 +977,7 @@ If you need another version mix please open an [issue](https://github.com/erikva
 
 (*) Only the versions 2.1.4 and 2.1.5 support OSGI.
 
-(**) Metrics-core 2.2.0 has a small [bug](https://github.com/codahale/metrics/issues/318) that makes it inconvenient to use JMX.
+(**) Metrics-core 2.2.0 has a small [bug](https://github.com/dropwizard/metrics/issues/318) that makes it inconvenient to use JMX.
 
 (***) Metrics-scala `3.0.1`, `3.0.2` and `3.0.3` erroneously depend on Akka `[2.2,)`.
 When Akka came with pre-releases of 2.3 this wont work (2.2 and 2.3 are not binary compatible).

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -42,7 +42,7 @@ There are Scala wrappers for each metric type: [gauge](#gauges), [counter](#coun
 There are also helper methods to instrument [Futures](Futures.md) and [Actors](Actors.md).
 
 For more information on (JMX) reporters and other aspects of Metrics 3.x, please see the Java api in the
-[Metrics documentation](http://metrics.codahale.com).
+[Metrics documentation](http://metrics.dropwizard.io).
 
 ## Version 3.5.4 and earlier
 

--- a/docs/Manual_2x.md
+++ b/docs/Manual_2x.md
@@ -24,7 +24,7 @@ There are Scala wrappers for each metric type: `gauge`, `counter`, `histogram`, 
 
 There is no special support for Health Checks, JMX or other Reporters. For more information on these please see the Metrics 2.x
 [documentation in the Way Back Machine](http://web.archive.org/web/20120925003800/http://metrics.codahale.com/manual/core/)
-or read it directly from [Metrics 2.2.0 git branch](https://github.com/codahale/metrics/tree/v2.2.0/docs/source/manual).
+or read it directly from [Metrics 2.2.0 manual](http://metrics.dropwizard.io/2.2.0/manual/).
 
 # Gauges
 


### PR DESCRIPTION
metrics.codahale.com and github.com/codahale/metrics have been migrated to
metrics.dropwizard.io and github.com/dropwizard/metrics respectively.

metrics.dropwizard.io hosts documentation for 2.2.0 and several 3.y.z versions.