### PR TITLE
Optimize MetricName

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,7 @@ lazy val metricsScala = (project in file("metrics-scala"))
     description := "metrics-scala for Scala " + CrossVersion.binaryScalaVersion(scalaVersion.value),
     libraryDependencies ++= Seq(
       "io.dropwizard.metrics" % "metrics-core" % "4.0.3",
-      "io.dropwizard.metrics" % "metrics-healthchecks" % "4.0.3",
-      "org.apache.commons" % "commons-lang3" % "3.8.1"
+      "io.dropwizard.metrics" % "metrics-healthchecks" % "4.0.3"
     ),
     mimaPreviousArtifacts := Set("nl.grons" %% "metrics4-scala" % "4.0.1")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,8 @@ lazy val metricsScala = (project in file("metrics-scala"))
     description := "metrics-scala for Scala " + CrossVersion.binaryScalaVersion(scalaVersion.value),
     libraryDependencies ++= Seq(
       "io.dropwizard.metrics" % "metrics-core" % "4.0.3",
-      "io.dropwizard.metrics" % "metrics-healthchecks" % "4.0.3"
+      "io.dropwizard.metrics" % "metrics-healthchecks" % "4.0.3",
+      "org.apache.commons" % "commons-lang3" % "3.8.1"
     ),
     mimaPreviousArtifacts := Set("nl.grons" %% "metrics4-scala" % "4.0.1")
   )

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
@@ -32,8 +32,8 @@ object MetricName {
       StringUtils.replace(_: String, "$apply", "."),
       dollarDigitsPattern.matcher(_: String).replaceAll("."),
       StringUtils.replace(_: String, ".package.", "."),
-      StringUtils.normalizeDots(_: String)
-    )
+      StringUtils.collapseDots(_: String)
+    ).reduce(_ andThen _)
   }
 
   /**
@@ -58,7 +58,7 @@ object MetricName {
    */
   def apply(name: String, names: String*): MetricName = new MetricName(name).append(names: _*)
 
-  private def removeScalaParts(s: String): String = classNameFilters.reduce(_ andThen _)(s)
+  private def removeScalaParts(s: String): String = classNameFilters(s)
 
 }
 

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
@@ -82,8 +82,7 @@ class MetricName private (val name: String) {
 
     val sb = new StringBuilder(name)
     names.view
-      .filter(_ != null)
-      .filter(_.nonEmpty)
+      .filter(n => n != null && n.nonEmpty)
       .foreach { newNamePart =>
         sb.append('.')
         sb.append(newNamePart)

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
@@ -18,8 +18,6 @@ package nl.grons.metrics4.scala
 
 import java.util.regex.Pattern
 
-import org.apache.commons.lang3.StringUtils
-
 object MetricName {
 
   // Example weird class name: TestContext$$anonfun$2$$anonfun$apply$TestObject$2$
@@ -34,7 +32,7 @@ object MetricName {
       StringUtils.replace(_: String, "$apply", "."),
       dollarDigitsPattern.matcher(_: String).replaceAll("."),
       StringUtils.replace(_: String, ".package.", "."),
-      normalizeDots(_: String)
+      StringUtils.normalizeDots(_: String)
     )
   }
 
@@ -62,34 +60,6 @@ object MetricName {
 
   private def removeScalaParts(s: String): String = classNameFilters.reduce(_ andThen _)(s)
 
-  private def normalizeDots(s: String): String = {
-    val scratchpad = s.toCharArray
-
-    var pos, newPos = 0
-    var currentChar = ' '
-    var inDots = false
-
-    while (pos < scratchpad.length) {
-      currentChar = scratchpad(pos)
-      if (currentChar != '.') {
-        scratchpad(newPos) = currentChar
-        inDots = false
-        newPos += 1
-      } else if (!inDots) {
-        scratchpad(newPos) = '.'
-        inDots = true
-        newPos += 1
-      }
-      pos += 1
-    }
-
-    if (scratchpad(newPos - 1) == '.') {
-      newPos -= 1
-    }
-    val offset = if (scratchpad(0) == '.') 1 else 0
-
-    new String(scratchpad, offset, newPos)
-  }
 }
 
 /**
@@ -112,8 +82,7 @@ class MetricName private (val name: String) {
 
     val sb = new StringBuilder(name)
     names.view
-      .filter(_ != null)
-      .filter(_.nonEmpty)
+      .filterNot(StringUtils.isEmpty)
       .foreach { newNamePart =>
         sb.append('.')
         sb.append(newNamePart)

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
@@ -82,7 +82,8 @@ class MetricName private (val name: String) {
 
     val sb = new StringBuilder(name)
     names.view
-      .filterNot(StringUtils.isEmpty)
+      .filter(_ != null)
+      .filter(_.nonEmpty)
       .foreach { newNamePart =>
         sb.append('.')
         sb.append(newNamePart)

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
@@ -62,7 +62,7 @@ private object StringUtils {
     * @return a [[String]] with all occurrences of `searchString` replaced with `replacement`
     */
   def replace(text: String, searchString: String, replacement: String): String =  {
-    if (isEmpty(text) || isEmpty(searchString) || replacement == null) {
+    if (text.isEmpty || searchString.isEmpty) {
       return text
     }
 
@@ -86,16 +86,6 @@ private object StringUtils {
     }
     sb.append(text.substring(start))
     sb.toString
-  }
-
-  /**
-    * Determine if given [[String]] is `null` or has length equal to 0.
-    *
-    * @param s the [[String]] to check
-    * @return a [[Boolean]], true iff `s` is null or has length equal to 0.
-    */
-  def isEmpty(s: String): Boolean = {
-    s == null || s.length == 0
   }
 
 }

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
@@ -34,7 +34,7 @@ private object StringUtils {
     }
     val offset = if (scratchpad(0) == '.') 1 else 0
 
-    new String(scratchpad, offset, newPos)
+    new String(scratchpad, offset, newPos - offset)
   }
 
   /**

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
@@ -1,0 +1,88 @@
+package nl.grons.metrics4.scala
+
+private object StringUtils {
+
+  /**
+    * Normalize dots and return the resulting [[String]].
+    *
+    * Normalizing dots means collapsing all adjacent occurrences of '.' to a single
+    * character and stripping leading and trailing '.'.
+    *
+    * @param s the [[String]] to normalize
+    * @return a normalized [[String]]
+    */
+  def normalizeDots(s: String): String = {
+    val scratchpad = s.toCharArray
+
+    var pos, newPos = 0
+    var currentChar = ' '
+    var inDots = false
+
+    while (pos < scratchpad.length) {
+      currentChar = scratchpad(pos)
+      if (currentChar != '.') {
+        scratchpad(newPos) = currentChar
+        inDots = false
+        newPos += 1
+      } else if (!inDots) {
+        scratchpad(newPos) = '.'
+        inDots = true
+        newPos += 1
+      }
+      pos += 1
+    }
+
+    if (scratchpad(newPos - 1) == '.') {
+      newPos -= 1
+    }
+    val offset = if (scratchpad(0) == '.') 1 else 0
+
+    new String(scratchpad, offset, newPos)
+  }
+
+  /**
+    * Replace all occurrences of `searchString` in `text` with `replacement`.
+    *
+    * @param text the [[String]] to perform the replacements in
+    * @param searchString the [[String]] that should be replaced
+    * @param replacement the [[String]] that should be put in place of `searchString`
+    * @return a [[String]] with all occurrences of `searchString` replaced with `replacement`
+    */
+  def replace(text: String, searchString: String, replacement: String): String =  {
+    if (isEmpty(text) || isEmpty(searchString) || replacement == null) {
+      return text
+    }
+
+    var start = 0
+    var end = text.indexOf(searchString, start)
+    if (end == -1) {
+      return text
+    }
+
+    val replLength = searchString.length
+    val increase = {
+      val diff = replacement.length - replLength
+      math.max(diff, 0) * 16
+    }
+
+    val sb = new StringBuilder(text.length + increase)
+    while (end != -1)  {
+      sb.append(text.substring(start, end)).append(replacement)
+      start = end + replLength
+      end = text.indexOf(searchString, start)
+    }
+    sb.append(text.substring(start))
+    sb.toString
+  }
+
+  /**
+    * Determine if given [[String]] is `null` or has length equal to 0.
+    *
+    * @param s the [[String]] to check
+    * @return a [[Boolean]], true iff `s` is null or has length equal to 0.
+    */
+  def isEmpty(s: String): Boolean = {
+    s == null || s.length == 0
+  }
+
+}

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2013-2018 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package nl.grons.metrics4.scala
 
 private object StringUtils {

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
@@ -3,15 +3,12 @@ package nl.grons.metrics4.scala
 private object StringUtils {
 
   /**
-    * Normalize dots and return the resulting [[String]].
-    *
-    * Normalizing dots means collapsing all adjacent occurrences of '.' to a single
-    * character and stripping leading and trailing '.'.
+    * Collapse adjacent dots, strip leading and trailing dot and return the resulting [[String]].
     *
     * @param s the [[String]] to normalize
     * @return a normalized [[String]]
     */
-  def normalizeDots(s: String): String = {
+  def collapseDots(s: String): String = {
     val scratchpad = s.toCharArray
 
     var pos, newPos = 0

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2013-2018 Erik van Oosten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package nl.grons.metrics4.scala
 
 import org.scalatest.Matchers._

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
@@ -48,16 +48,8 @@ class StringUtilsSpec extends FunSpec {
   }
 
   describe("replace") {
-    it("doesn't replace anything in null Strings") {
-      StringUtils.replace(null, "foo", "bar") should equal (null)
-    }
-
     it("doesn't replace anything in empty Strings") {
       StringUtils.replace("", "foo", "bar") should equal ("")
-    }
-
-    it("doesn't replace null") {
-      StringUtils.replace("foo", null, "bar") should equal ("foo")
     }
 
     it("doesn't replace empty String") {
@@ -77,17 +69,4 @@ class StringUtilsSpec extends FunSpec {
     }
   }
 
-  describe("isEmpty") {
-    it("recognizes nulls as empty") {
-      StringUtils.isEmpty(null) should be (true)
-    }
-
-    it("recognizes empty String as empty") {
-      StringUtils.isEmpty("") should be (true)
-    }
-
-    it("recognizes non-empty String as not empty") {
-      StringUtils.isEmpty("foo") should be (false)
-    }
-  }
 }

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
@@ -1,0 +1,77 @@
+package nl.grons.metrics4.scala
+
+import org.scalatest.Matchers._
+import org.scalatest.FunSpec
+
+class StringUtilsSpec extends FunSpec {
+
+  describe("collapseDots") {
+    it("strips leading dot") {
+      StringUtils.collapseDots(".foo.bar") should equal ("foo.bar")
+    }
+
+    it("strips trailing dot") {
+      StringUtils.collapseDots("foo.bar.") should equal ("foo.bar")
+    }
+
+    it("collapses dots at the beginning of the String") {
+      StringUtils.collapseDots("....foo.bar") should equal ("foo.bar")
+    }
+
+    it("collapses dots at the end of the String") {
+      StringUtils.collapseDots("foo.bar....") should equal ("foo.bar")
+    }
+
+    it("collapses dots in the middle of the String") {
+      StringUtils.collapseDots("foo....bar...baz") should equal ("foo.bar.baz")
+    }
+
+    it("doesn't modify an already valid String") {
+      StringUtils.collapseDots("foo.bar.baz") should equal ("foo.bar.baz")
+    }
+  }
+
+  describe("replace") {
+    it("doesn't replace anything in null Strings") {
+      StringUtils.replace(null, "foo", "bar") should equal (null)
+    }
+
+    it("doesn't replace anything in empty Strings") {
+      StringUtils.replace("", "foo", "bar") should equal ("")
+    }
+
+    it("doesn't replace null") {
+      StringUtils.replace("foo", null, "bar") should equal ("foo")
+    }
+
+    it("doesn't replace empty String") {
+      StringUtils.replace("foo", "", "bar") should equal ("foo")
+    }
+
+    it("replaces repeated occurrences") {
+      StringUtils.replace("queued", "ue", "") should equal ("qd")
+    }
+
+    it("doesn't replace non-matching String") {
+      StringUtils.replace("queued", "zz", "") should equal ("queued")
+    }
+
+    it("can replace with a longer String") {
+      StringUtils.replace("abXYab", "ab", "foobar") should equal ("foobarXYfoobar")
+    }
+  }
+
+  describe("isEmpty") {
+    it("recognizes nulls as empty") {
+      StringUtils.isEmpty(null) should be (true)
+    }
+
+    it("recognizes empty String as empty") {
+      StringUtils.isEmpty("") should be (true)
+    }
+
+    it("recognizes non-empty String as not empty") {
+      StringUtils.isEmpty("foo") should be (false)
+    }
+  }
+}


### PR DESCRIPTION
Hey! During some internal benchmarking I discovered that MetricName class can become a bottle neck if a lot of metric names a generated dynamically on the hot path. 
Looking at the code, there were a few things slowing it down:
- `String.replaceAllLiterally` is very slow prior to Java 9
- `String.replaceAll` compiles regex on each method call
- `MetricName.append` was doing some unnecessary work

Some basic benchmarks, ran on Mid 2015 MacBook Pro with 2.5GHz Core i7
```
$ java -version
java version "1.8.0_172"
Java(TM) SE Runtime Environment (build 1.8.0_172-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.172-b11, mixed mode)
```

```
Benchmark                                                                       (className)  Mode  Cnt     Score     Error  Units
BenchMetricName.appendOld                                                 java.util.HashMap  avgt    5  1249.212 ±  35.993  ns/op
BenchMetricName.appendOld           com.sumologic.benchmark.bench.metrics_scala.TestClassA$  avgt    5  1765.970 ± 337.021  ns/op
BenchMetricName.appendOptimized                                           java.util.HashMap  avgt    5   218.687 ±  41.918  ns/op
BenchMetricName.appendOptimized     com.sumologic.benchmark.bench.metrics_scala.TestClassA$  avgt    5   221.283 ±   6.072  ns/op
BenchMetricName.fromClassOld                                              java.util.HashMap  avgt    5  2704.233 ± 146.685  ns/op
BenchMetricName.fromClassOld        com.sumologic.benchmark.bench.metrics_scala.TestClassA$  avgt    5  3520.235 ± 624.656  ns/op
BenchMetricName.fromClassOptimized                                        java.util.HashMap  avgt    5   223.203 ±  37.580  ns/op
BenchMetricName.fromClassOptimized  com.sumologic.benchmark.bench.metrics_scala.TestClassA$  avgt    5   609.280 ±  22.542  ns/op
BenchMetricName.fromNameOld                                               java.util.HashMap  avgt    5   437.847 ±   3.476  ns/op
BenchMetricName.fromNameOld         com.sumologic.benchmark.bench.metrics_scala.TestClassA$  avgt    5   630.851 ±   6.655  ns/op
BenchMetricName.fromNameOptimized                                         java.util.HashMap  avgt    5     3.750 ±   0.021  ns/op
BenchMetricName.fromNameOptimized   com.sumologic.benchmark.bench.metrics_scala.TestClassA$  avgt    5     3.755 ±   0.014  ns/op
```
