### PR TITLE
fix(timer): fixes race condition, which leads to flaky tests.

### DIFF
--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Timer.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Timer.scala
@@ -96,8 +96,10 @@ class Timer(private[scala] val metric: DropwizardTimer) {
         ctx.stop()
         throw ex
     }
-    f.onComplete(_ => ctx.stop())
-    f
+    f.map{ r =>
+      ctx.stop()
+      r
+    }
   }
 
   /**

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Timer.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Timer.scala
@@ -96,7 +96,7 @@ class Timer(private[scala] val metric: DropwizardTimer) {
         ctx.stop()
         throw ex
     }
-    f.map{ r =>
+    f.transform{ r =>
       ctx.stop()
       r
     }


### PR DESCRIPTION
awaiting the completion of the future doesn't guarantee ctx.stop() was called. 