### PR TITLE
Scala 3, Akka 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-v4.1.20: Nov 2021
+v4.2.7: Dec 2021
 =================
 
 * Scala 3 support! Based on some very good work from @xuwei-k, thanks!
 * Introduced a version for Akka 2.6.
+* Updates: metrics-core: 4.1.29 -> 4.2.7, hdrhistogram-metrics-reservoir: 1.1.0 -> 1.1.3
 
 v4.1.19: Apr 2021
 =================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v4.1.20: Nov 2021
+=================
+
+* Scala 3 support! Based on some very good work from @xuwei-k, thanks!
+* Introduced a version for Akka 2.6.
+
 v4.1.19: Apr 2021
 =================
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
 Metrics-scala
-Copyright 2013-2020 Erik van Oosten
+Copyright 2013-2021 Erik van Oosten
 
-This product includes software developed by Erik van Oosten. It is based on Metrics from Coda Hale and Yammer, Inc.
+This product includes software developed by Erik van Oosten and contributors. It is based on Metrics from Coda Hale and
+Yammer, Inc.

--- a/README.md
+++ b/README.md
@@ -148,9 +148,8 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
   </tbody>
 </table>
 
-(*) Akka needs at least Scala 3.1. Also, Scala 3.1 is not backward compatible with Scala 3.0.
-Therefore, there is no build for Scala 3.0. If you want to use Scala 3.x you will need to use
-at least Scala 3.1.
+(*) There is no build for Scala 3.0. If you want to use Scala 3.x you will need to use
+at least Scala 3.1. Note that Scala 3.1 is not backward compatible with Scala 3.0.
 
 (**) The first number is the version of `"org.mpierce.metrics.reservoir" % "hdrhistogram-metrics-reservoir"`,
 the second the version of `"org.hdrhistogram" % "HdrHistogram"`.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
       <td valign="top" rowspan="2">Build against</td>
     </tr>
     <tr>
-      <td valign="top">3.1</td>
+      <td valign="top">3.1 (*)</td>
       <td valign="top">2.13</td>
       <td valign="top">2.12</td>
       <td valign="top">2.11</td>
@@ -148,10 +148,9 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
   </tbody>
 </table>
 
-Because Akka needs at least Scala 3.1 and Scala 3.1 is not backward compatible with Scala 3.0,
-there is no build for Scala 3.0.
-
-(*) RC versions are only supported until the next version is available.
+(*) Akka needs at least Scala 3.1. Also, Scala 3.1 is not backward compatible with Scala 3.0.
+Therefore, there is no build for Scala 3.0. If you want to use Scala 3.x you will need to use
+at least Scala 3.1.
 
 (**) The first number is the version of `"org.mpierce.metrics.reservoir" % "hdrhistogram-metrics-reservoir"`,
 the second the version of `"org.hdrhistogram" % "HdrHistogram"`.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,6 @@ with the help of [@scullxbones](https://github.com/scullxbones) and many other c
 
 Copyright (c) 2010-2012 Coda Hale, Yammer.com (before 3.0.0)
 
-Copyright (c) 2013-2020 Erik van Oosten (3.0.0 and later)
+Copyright (c) 2013-2021 Erik van Oosten (3.0.0 and later)
 
 Published under Apache Software License 2.0, see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
-      <td valign="top">Dropwizard-metrics 4.1.19</td>
+      <td valign="top">Dropwizard-metrics 4.2.7</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a26</td>
@@ -143,7 +143,7 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
-      <td valign="top">Hdr 1.1.0/2.1.12 (**)</td>
+      <td valign="top">Hdr 1.1.3/2.1.12 (**)</td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ binary compatibility problems. Instead, use `"nl.grons" %% "metrics4-scala" % "4
 SBT:
 ```
 libraryDependencies ++= Seq(
-  "nl.grons" %% "metrics4-scala" % "4.1.20",
-  "nl.grons" %% "metrics4-akka_a26" % "4.1.20",
-  "nl.grons" %% "metrics4-scala-hdr" % "4.1.20"
+  "nl.grons" %% "metrics4-scala" % "4.2.7",
+  "nl.grons" %% "metrics4-akka_a26" % "4.2.7",
+  "nl.grons" %% "metrics4-scala-hdr" % "4.2.7"
 )
 ```
 
@@ -186,7 +186,7 @@ Maven:
 <properties>
     <scala.version>3.1.0</scala.version>
     <scala.compat.version>3</scala.compat.version>
-    <metrics.scala.version>4.1.20</metrics.scala.version>
+    <metrics.scala.version>4.2.7</metrics.scala.version>
 </properties>
 <dependency>
     <groupId>nl.grons</groupId>

--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
   <tbody>
     <tr>
       <td valign="top" rowspan="2">Artifact name</td>
-      <td valign="top" rowspan="1" colspan="3">Scala version</td>
+      <td valign="top" rowspan="1" colspan="4">Scala version</td>
       <td valign="top" rowspan="1" colspan="3">Akka version</td>
       <td valign="top" rowspan="2">Build against</td>
     </tr>
     <tr>
+      <td valign="top">3.1</td>
       <td valign="top">2.13</td>
       <td valign="top">2.12</td>
       <td valign="top">2.11</td>
@@ -94,13 +95,26 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top">✓</td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.19</td>
     </tr>
     <tr>
+      <td valign="top">metrics4-akka_a26</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">Akka 2.6.18</td>
+    </tr>
+    <tr>
       <td valign="top">metrics4-akka_a25</td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
@@ -111,6 +125,7 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a24</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -124,6 +139,7 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top">✓</td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -131,6 +147,9 @@ Akka versions see [all available versions](/docs/AvailableVersions.md).
     </tr>
   </tbody>
 </table>
+
+Because Akka needs at least Scala 3.1 and Scala 3.1 is not backward compatible with Scala 3.0,
+there is no build for Scala 3.0.
 
 (*) RC versions are only supported until the next version is available.
 
@@ -152,23 +171,23 @@ is not compatible over major Dropwizard versions.
 <a href="CHANGELOG.md#v4119-apr-2021">Release notes for 4.1.19.</a>
 
 WARNING: `nl.grons:metrics-scala:4.0.0` was accidentally released as well. *Do not use it* as it will give
-binary compatibility problems. Instead use `"nl.grons" %% "metrics4-scala" % "4.0.1"` or later as described below.
+binary compatibility problems. Instead, use `"nl.grons" %% "metrics4-scala" % "4.0.1"` or later as described below.
 
 SBT:
 ```
 libraryDependencies ++= Seq(
-  "nl.grons" %% "metrics4-scala" % "4.1.19",
-  "nl.grons" %% "metrics4-akka_a25" % "4.1.19",
-  "nl.grons" %% "metrics4-scala-hdr" % "4.1.19"
+  "nl.grons" %% "metrics4-scala" % "4.1.20",
+  "nl.grons" %% "metrics4-akka_a26" % "4.1.20",
+  "nl.grons" %% "metrics4-scala-hdr" % "4.1.20"
 )
 ```
 
 Maven:
 ```
 <properties>
-    <scala.version>2.13.0</scala.version>
-    <scala.compat.version>2.13</scala.compat.version>
-    <metrics.scala.version>4.1.19</metrics.scala.version>
+    <scala.version>3.1.0</scala.version>
+    <scala.compat.version>3</scala.compat.version>
+    <metrics.scala.version>4.1.20</metrics.scala.version>
 </properties>
 <dependency>
     <groupId>nl.grons</groupId>
@@ -177,7 +196,7 @@ Maven:
 </dependency>
 <dependency>
     <groupId>nl.grons</groupId>
-    <artifactId>metrics4-akka_a25_${scala.compat.version}</artifactId>
+    <artifactId>metrics4-akka_a26_${scala.compat.version}</artifactId>
     <version>${metrics.scala.version}</version>
 </dependency>
 <dependency>

--- a/build.sbt
+++ b/build.sbt
@@ -88,8 +88,8 @@ lazy val metricsAkka26 = (project in file("metrics-akka-26"))
     libraryDependencies ++= {
       if (scalaVersion.value.startsWith("3.")) {
         Seq(
-          "com.typesafe.akka" %% "akka-actor" % "2.6.17+25-527571fc-SNAPSHOT",
-          "com.typesafe.akka" %% "akka-testkit" % "2.6.17+3-63aa4eaa-SNAPSHOT" % Test
+          "com.typesafe.akka" %% "akka-actor" % "2.6.18",
+          "com.typesafe.akka" %% "akka-testkit" % "2.6.18" % Test
         )
       } else {
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val commonSettings = Seq(
   crossVersion := CrossVersion.binary,
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.2.10" % Test,
-    "org.mockito" %% "mockito-scala" % "1.16.46" % Test,
+    "org.mockito" % "mockito-core" % "3.6.0" % Test,
     "org.slf4j" % "slf4j-simple" % "1.7.32" % Test
   ),
   fork := true,

--- a/docs/AvailableVersions.md
+++ b/docs/AvailableVersions.md
@@ -28,7 +28,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">2.6</td>
     </tr>
     <tr>
-      <td valign="top" rowspan="5"><a href="/CHANGELOG.md#v4120-nov-2021">4.1.20</a></td>
+      <td valign="top" rowspan="5"><a href="/CHANGELOG.md#v427-nov-2021">4.2.7</a></td>
       <td valign="top">metrics4-scala</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>

--- a/docs/AvailableVersions.md
+++ b/docs/AvailableVersions.md
@@ -14,7 +14,7 @@ The table shows the available 4.x artifacts of metrics-scala.
     <tr>
       <td valign="top" rowspan="2">Metrics-<br>scala<br>version</td>
       <td valign="top" rowspan="2">Artifact name</td>
-      <td valign="top" rowspan="1" colspan="3">Scala version</td>
+      <td valign="top" rowspan="1" colspan="4">Scala version</td>
       <td valign="top" rowspan="1" colspan="3">Akka version</td>
       <td valign="top" rowspan="2">Build against</td>
     </tr>
@@ -22,13 +22,15 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">2.11</td>
       <td valign="top">2.12</td>
       <td valign="top">2.13</td>
+      <td valign="top">3.1</td>
       <td valign="top">2.4</td>
       <td valign="top">2.5</td>
       <td valign="top">2.6</td>
     </tr>
     <tr>
-      <td valign="top" rowspan="4"><a href="/CHANGELOG.md#v4119-apr-2021">4.1.19</a></td>
+      <td valign="top" rowspan="5"><a href="/CHANGELOG.md#v4120-nov-2021">4.1.20</a></td>
       <td valign="top">metrics4-scala</td>
+      <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -38,10 +40,22 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">Dropwizard-metrics 4.1.19</td>
     </tr>
     <tr>
+      <td valign="top">metrics4-akka_a26</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">✓</td>
+      <td valign="top">Akka 2.6.18</td>
+    </tr>
+    <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -51,6 +65,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -62,6 +77,52 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">Hdr 1.1.0/2.1.12 (**)</td>
+    </tr>
+    <tr>
+      <td valign="top" rowspan="4"><a href="/CHANGELOG.md#v4119-apr-2021">4.1.19</a></td>
+      <td valign="top">metrics4-scala</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">Dropwizard-metrics 4.1.19</td>
+    </tr>
+    <tr>
+      <td valign="top">metrics4-akka_a25</td>
+      <td valign="top"></td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top">Akka 2.5.31</td>
+    </tr>
+    <tr>
+      <td valign="top">metrics4-akka_a24</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
+      <td valign="top"></td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top">Akka 2.4.20</td>
+    </tr>
+    <tr>
+      <td valign="top">metrics4-scala-hdr</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -76,6 +137,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.14</td>
     </tr>
     <tr>
@@ -83,6 +145,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -92,6 +155,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -103,6 +167,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -117,6 +182,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.9</td>
     </tr>
     <tr>
@@ -124,6 +190,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -133,6 +200,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -144,6 +212,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -158,6 +227,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.5</td>
     </tr>
     <tr>
@@ -165,6 +235,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -174,6 +245,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -185,6 +257,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -199,6 +272,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.4</td>
     </tr>
     <tr>
@@ -206,6 +280,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -215,6 +290,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -226,6 +302,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -240,6 +317,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.1</td>
     </tr>
     <tr>
@@ -247,6 +325,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -256,6 +335,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -267,6 +347,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -281,6 +362,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.0</td>
     </tr>
     <tr>
@@ -288,6 +370,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -297,6 +380,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -308,6 +392,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -322,6 +407,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.0</td>
     </tr>
     <tr>
@@ -329,6 +415,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -338,6 +425,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-akka_a24</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -349,6 +437,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -363,12 +452,14 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.1.0</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
@@ -380,6 +471,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -389,6 +481,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-scala-hdr</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -404,12 +497,14 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.0.5</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
@@ -421,6 +516,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -430,6 +526,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-scala-hdr</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -445,12 +542,14 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.0.5</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
@@ -462,6 +561,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -471,6 +571,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-scala-hdr</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -486,12 +587,14 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.0.3</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
@@ -503,6 +606,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -512,6 +616,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-scala-hdr</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -527,12 +632,14 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.0.3</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
@@ -544,6 +651,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -553,6 +661,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-scala-hdr</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
@@ -568,12 +677,14 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">Dropwizard-metrics 4.0.1</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a25</td>
       <td valign="top"></td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top">✓</td>
@@ -585,6 +696,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top"></td>
+      <td valign="top"></td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
@@ -594,6 +706,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top">metrics4-scala-hdr</td>
       <td valign="top">✓</td>
       <td valign="top">✓</td>
+      <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>

--- a/docs/AvailableVersions.md
+++ b/docs/AvailableVersions.md
@@ -715,7 +715,7 @@ The table shows the available 4.x artifacts of metrics-scala.
     </tr>
     <tr>
       <td valign="top">4.0.0</td>
-      <td valign="top" colspan="7">Do not use! (***)</td>
+      <td valign="top" colspan="9">Do not use! (***)</td>
     </tr>
   </tbody>
 </table>

--- a/docs/AvailableVersions.md
+++ b/docs/AvailableVersions.md
@@ -37,7 +37,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
-      <td valign="top">Dropwizard-metrics 4.1.19</td>
+      <td valign="top">Dropwizard-metrics 4.2.7</td>
     </tr>
     <tr>
       <td valign="top">metrics4-akka_a26</td>
@@ -81,7 +81,7 @@ The table shows the available 4.x artifacts of metrics-scala.
       <td valign="top"></td>
       <td valign="top"></td>
       <td valign="top"></td>
-      <td valign="top">Hdr 1.1.0/2.1.12 (**)</td>
+      <td valign="top">Hdr 1.1.3/2.1.12 (**)</td>
     </tr>
     <tr>
       <td valign="top" rowspan="4"><a href="/CHANGELOG.md#v4119-apr-2021">4.1.19</a></td>

--- a/metrics-akka/src/main/scala/nl/grons/metrics4/scala/ActorMetrics.scala
+++ b/metrics-akka/src/main/scala/nl/grons/metrics4/scala/ActorMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-akka/src/test/scala/nl/grons/metrics4/scala/ActorInstrumentedLifeCycleSpec.scala
+++ b/metrics-akka/src/test/scala/nl/grons/metrics4/scala/ActorInstrumentedLifeCycleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-akka/src/test/scala/nl/grons/metrics4/scala/ActorMetricsSpec.scala
+++ b/metrics-akka/src/test/scala/nl/grons/metrics4/scala/ActorMetricsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-akka/src/test/scala/nl/grons/metrics4/scala/ActorMetricsSpec.scala
+++ b/metrics-akka/src/test/scala/nl/grons/metrics4/scala/ActorMetricsSpec.scala
@@ -28,7 +28,7 @@ class ActorMetricsSpec extends AnyFunSpec with OneInstancePerTest {
   import ActorMetricsSpec._
   import akka.testkit.TestActorRef
 
-  implicit val system = ActorSystem()
+  implicit private val system: ActorSystem = ActorSystem()
 
   describe("A counter actor") {
     it("invokes original receive and increments counter on new messages") {

--- a/metrics-scala-hdr/src/main/scala/nl/grons/metrics4/scala/HdrMetricBuilder.scala
+++ b/metrics-scala-hdr/src/main/scala/nl/grons/metrics4/scala/HdrMetricBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala-hdr/src/test/scala/nl/grons/metrics4/scala/HdrMetricBuilderSpec.scala
+++ b/metrics-scala-hdr/src/test/scala/nl/grons/metrics4/scala/HdrMetricBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/BaseBuilder.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/BaseBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 Erik van Oosten
+ * Copyright (c) 2014-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/CheckedBuilder.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/CheckedBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Counter.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Counter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ class Counter(metric: DropwizardCounter) {
   /**
    * Wraps partial function pf, incrementing this counter for every execution (defined or not).
    */
-   def count[A,B](pf: PartialFunction[A,B]): PartialFunction[A,B] =
+  def count[A,B](pf: PartialFunction[A,B]): PartialFunction[A,B] =
      new PartialFunction[A,B] {
        def apply(a: A): B = {
           metric.inc(1)

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/DefaultInstrumented.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/DefaultInstrumented.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Erik van Oosten
+ * Copyright (c) 2016-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/FreshRegistries.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/FreshRegistries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Gauge.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Gauge.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Histogram.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Histogram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Implicits.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/InstrumentedBuilder.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/InstrumentedBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Meter.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Meter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class Meter(metric: DropwizardMeter) {
    *   }
    * }}}
    */
-  def exceptionMarker = new AnyRef() {
+  object exceptionMarker {
     def apply[A](f: => A): A = {
         try {
           f
@@ -87,7 +87,7 @@ class Meter(metric: DropwizardMeter) {
    *  }
    * }}}
    */
-  def exceptionMarkerPF = new AnyRef() {
+  object exceptionMarkerPF {
     def apply[A, B](pf: PartialFunction[A, B]): PartialFunction[A, B] =
       new PartialFunction[A, B] {
         def apply(a: A): B = {

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricBuilder.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MetricName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MoreImplicits.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/MoreImplicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/PushGauge.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/PushGauge.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Erik van Oosten
+ * Copyright (c) 2020-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/PushGaugeWithTimeout.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/PushGaugeWithTimeout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Erik van Oosten
+ * Copyright (c) 2020-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/StringUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Erik van Oosten
+ * Copyright (c) 2018-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Timer.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/Timer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CheckedBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CheckedBuilderSpec.scala
@@ -20,7 +20,7 @@ import java.text.SimpleDateFormat
 
 import com.codahale.metrics.health.HealthCheck.Result
 import com.codahale.metrics.health.{HealthCheck, HealthCheckRegistry}
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalactic.Equality
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
@@ -43,8 +43,8 @@ class HealthCheckSpec extends AnyFunSpec {
     }
 
     it("build health checks that call the provided checker") {
-      val mockChecker = mock[SimpleChecker]
-      when(mockChecker.check()).thenReturn(true, false, true, false)
+      val mockChecker = mock(classOf[SimpleChecker])
+      when(mockChecker.check()).thenReturn(true).thenReturn(false).thenReturn(true).thenReturn(false)
       val check = newCheckOwner.createCheckerHealthCheck(mockChecker)
       check.execute() should equal(Result.healthy())
       check.execute() should equal(Result.unhealthy("FAIL"))
@@ -221,7 +221,7 @@ private trait SimpleChecker {
 }
 
 private class CheckOwner() extends CheckedBuilder {
-  val registry: HealthCheckRegistry = mock[HealthCheckRegistry]
+  val registry: HealthCheckRegistry = mock(classOf[HealthCheckRegistry])
 
   // Unfortunately we need a helper method for each supported type. If we wanted a single helper method,
   // we would need to repeat the magnet pattern right here in a test class :(

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CheckedBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CheckedBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CombinedBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CombinedBuilderSpec.scala
@@ -18,7 +18,7 @@ package nl.grons.metrics4.scala
 
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.health.{HealthCheck, HealthCheckRegistry}
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
 import org.scalatest.funspec.AnyFunSpec
 
@@ -49,8 +49,8 @@ class CombinedBuilderSpec extends AnyFunSpec with OneInstancePerTest {
   }
 
   private class CombinedBuilder() extends InstrumentedBuilder with CheckedBuilder {
-    val metricRegistry: MetricRegistry = mock[MetricRegistry]
-    val registry: HealthCheckRegistry = mock[HealthCheckRegistry]
+    val metricRegistry: MetricRegistry = mock(classOf[MetricRegistry])
+    val registry: HealthCheckRegistry = mock(classOf[HealthCheckRegistry])
 
     def createCounter(): Counter = metrics.counter("cnt")
 

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CombinedBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CombinedBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CounterSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CounterSpec.scala
@@ -16,7 +16,7 @@
 
 package nl.grons.metrics4.scala
 
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -94,7 +94,7 @@ class CounterSpec extends AnyFunSpec {
   }
 
   private def withMockCounter[A](testCode: (com.codahale.metrics.Counter, Counter) => A): A = {
-    val mockDwCounter = mock[com.codahale.metrics.Counter]
+    val mockDwCounter = mock(classOf[com.codahale.metrics.Counter])
     val counter = new Counter(mockDwCounter)
     testCode(mockDwCounter, counter)
   }

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CounterSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/CounterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/DefaultInstrumentedSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/DefaultInstrumentedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Erik van Oosten
+ * Copyright (c) 2016-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/FreshRegistriesSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/FreshRegistriesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/GaugeSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/GaugeSpec.scala
@@ -16,14 +16,14 @@
 
 package nl.grons.metrics4.scala
 
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
 
 class GaugeSpec extends AnyFunSpec with OneInstancePerTest {
   describe("A gauge") {
-    val metric = mock[com.codahale.metrics.Gauge[Int]]
+    val metric = mock(classOf[com.codahale.metrics.Gauge[Int]])
     val gauge = new Gauge(metric)
 
     it("invokes underlying function for sugar factory") {

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/GaugeSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/GaugeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/HistogramSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/HistogramSpec.scala
@@ -16,14 +16,14 @@
 
 package nl.grons.metrics4.scala
 
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
 
 class HistogramSpec extends AnyFunSpec with OneInstancePerTest {
   describe("A histogram") {
-    val metric = mock[com.codahale.metrics.Histogram]
+    val metric = mock(classOf[com.codahale.metrics.Histogram])
     val histogram = new Histogram(metric)
 
     it("updates the underlying histogram with an int") {
@@ -39,7 +39,7 @@ class HistogramSpec extends AnyFunSpec with OneInstancePerTest {
     }
 
     it("retrieves a snapshot for statistics") {
-      val snapshot = mock[com.codahale.metrics.Snapshot]
+      val snapshot = mock(classOf[com.codahale.metrics.Snapshot])
       when(snapshot.getMax).thenReturn(1L)
       when(metric.getSnapshot).thenReturn(snapshot)
 

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/HistogramSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/HistogramSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/ImplicitsSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/ImplicitsSpec.scala
@@ -18,8 +18,8 @@ package nl.grons.metrics4.scala
 
 import com.codahale.metrics.MetricRegistry.MetricSupplier
 import com.codahale.metrics.{Metric, MetricFilter}
-import org.mockito.ArgumentMatchersSugar.same
-import org.mockito.MockitoSugar._
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -52,10 +52,10 @@ class ImplicitsSpec extends AnyFunSpec {
 
   describe("Implicits.functionToMetricFilter") {
     it("creates a MetricFilter that passes arguments to the function and returns function result unchanged") {
-      val f = mock[(String, Metric) => Boolean]
+      val f = mock(classOf[(String, Metric) => Boolean])
       val dummyName = "dummy"
       val dummyMetric = new Metric {}
-      when(f.apply(same(dummyName), same(dummyMetric))).thenReturn(true, false)
+      when(f.apply(same(dummyName), same(dummyMetric))).thenReturn(true).thenReturn(false)
       val metricFilter: MetricFilter = Implicits.functionToMetricFilter(f)
       metricFilter.matches(dummyName, dummyMetric) shouldBe true
       metricFilter.matches(dummyName, dummyMetric) shouldBe false
@@ -64,7 +64,7 @@ class ImplicitsSpec extends AnyFunSpec {
 
   describe("Implicits.functionToMetricSupplier") {
     it("creates a MetricSupplier that wraps the function unchanged") {
-      val f = mock[() => Metric]
+      val f = mock(classOf[() => Metric])
       val dummyMetric1 = new Metric {}
       val dummyMetric2 = new Metric {}
       when(f.apply()).thenReturn(dummyMetric1, dummyMetric2)

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/ImplicitsSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/ImplicitsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/InstrumentedBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/InstrumentedBuilderSpec.scala
@@ -17,7 +17,7 @@
 package nl.grons.metrics4.scala
 
 import com.codahale.metrics.MetricRegistry
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
 import org.scalatest.funspec.AnyFunSpec
 
@@ -40,7 +40,7 @@ class InstrumentedBuilderSpec extends AnyFunSpec with OneInstancePerTest {
   }
 
   private class MetricOwner() extends InstrumentedBuilder {
-    val metricRegistry: MetricRegistry = mock[MetricRegistry]
+    val metricRegistry: MetricRegistry = mock(classOf[MetricRegistry])
 
     def createCounter(): Counter = metrics.counter("cnt")
   }

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/InstrumentedBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/InstrumentedBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 Erik van Oosten
+ * Copyright (c) 2014-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MeterSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MeterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MeterSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MeterSpec.scala
@@ -16,14 +16,14 @@
 
 package nl.grons.metrics4.scala
 
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
 
 class MeterSpec extends AnyFunSpec with OneInstancePerTest {
   describe("A meter") {
-    val metric = mock[com.codahale.metrics.Meter]
+    val metric = mock(classOf[com.codahale.metrics.Meter])
     val meter = new Meter(metric)
 
     it("marks the underlying metric") {

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MetricBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MetricBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MetricNameSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MetricNameSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/StringUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Erik van Oosten
+ * Copyright (c) 2018-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/TimerSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/TimerSpec.scala
@@ -18,7 +18,7 @@ package nl.grons.metrics4.scala
 
 import java.util.concurrent.TimeUnit
 
-import org.mockito.MockitoSugar._
+import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
 import org.scalatest.OptionValues._
 import org.scalatest.TryValues._
@@ -42,9 +42,9 @@ class TimerSpec extends AnyFunSpec with OneInstancePerTest {
   import TimerSpec._
 
   describe("A timer") {
-    val metric = mock[com.codahale.metrics.Timer]
+    val metric = mock(classOf[com.codahale.metrics.Timer])
     val timer = new Timer(metric)
-    val context = mock[com.codahale.metrics.Timer.Context]
+    val context = mock(classOf[com.codahale.metrics.Timer.Context])
     when(metric.time()).thenReturn(context)
 
     it("times the passed closure") {

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/TimerSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/TimerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/package.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Erik van Oosten
+ * Copyright (c) 2013-2021 Erik van Oosten
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/releasechecklist.md
+++ b/releasechecklist.md
@@ -2,7 +2,7 @@
 
 1. Double check documentation is up to date.
 2. Validate entry in CHANGELOG.md
-4. Run `sbt ';+clean;+test;+package'`
+4. Run `sbt ';+clean;+test;+package;+mimaFindBinaryIssues;'`
 5. Push changes, e.g.`git commit -m 'Releasing 4.x.x'`
 6. Set tag `git tag v4.x.x`
 6. Optionally test signed publishing with `./crossrelease.sh publishLocalSigned` 


### PR DESCRIPTION
Introduces Scala 3 and Akka 2.6. The first version to support Scala 3 properly is to-be-released Akka 2.6.18 (see https://github.com/akka/akka/issues/30243#issuecomment-955710653). We use a snapshot for now. Once 2.6.18 is out this PR can be merged and a release can be created.

Builds on top of #365 from @xuwei-k.

Also:
 - uses the correct previous version for scala 2.13 in the Mima check
 - puts the Mima check in the release process
 - fixes indentation in Counter.scala
 - updates copyright statements for 2021

Still todo:
 - [x] Update Akka version to 2.6.18 as soon as its out
 - [x] Update docs/AvailableVersions.md
 - [x] Update README.md
 - [x] Update CHANGELOG.md
