### PR TITLE
Implement PushGauge using Dropwizard's SettableGauge

### DIFF
--- a/metrics-scala/src/main/scala/nl/grons/metrics4/scala/PushGauge.scala
+++ b/metrics-scala/src/main/scala/nl/grons/metrics4/scala/PushGauge.scala
@@ -16,16 +16,14 @@
 
 package nl.grons.metrics4.scala
 
-import java.util.concurrent.atomic.AtomicReference
+import com.codahale.metrics.{SettableGauge => DropwizardSettableGauge}
 
 /**
  * A gauge to which you can push new values.
  *
  * Can only be constructed via [[MetricBuilder.pushGauge]].
  */
-class PushGauge[A] private[scala](startValue: A) {
-
-  private val valueRef = new AtomicReference[A](startValue)
+class PushGauge[A](metric: DropwizardSettableGauge[A])  {
 
   /**
    * Push a new value.
@@ -35,7 +33,7 @@ class PushGauge[A] private[scala](startValue: A) {
    *                 ignore this metric (verified for the standard reporters: `GraphiteReporter` and
    *                 `CollectdReporter`).
    */
-  def push(newValue: A): Unit = valueRef.set(newValue)
+  def push(newValue: A): Unit = metric.setValue(newValue)
 
   /** Alias for [[push]]. */
   def value_=(newValue: A): Unit = push(newValue)
@@ -43,6 +41,6 @@ class PushGauge[A] private[scala](startValue: A) {
   /**
    * The current value.
    */
-  def value: A = valueRef.get
+  def value: A = metric.getValue
 
 }

--- a/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MetricBuilderSpec.scala
+++ b/metrics-scala/src/test/scala/nl/grons/metrics4/scala/MetricBuilderSpec.scala
@@ -120,6 +120,12 @@ class MetricBuilderSpec extends AnyFunSpec with OneInstancePerTest {
       underTest.meterPlusEleven()
       underTest.meter.count should equal (11)
     }
+
+    it("can re-fetch push gauges") {
+      val name = "foobar"
+      underTest.metrics.pushGauge(name, 0)
+      underTest.metrics.pushGauge(name, 0)
+    }
   }
 
 }


### PR DESCRIPTION
The benefit is that we use `registry.gauge()` to create and register it,
which uses `getOrAdd` in the registry, which means that if `pushGauge`
is called twice with the same name it won't throw the "A metric named
foobar already exists" error - it will just return the old SettableGauge.


fixes #405 

Without this change, the test I added fails with:
```
A metric named nl.grons.metrics4.scala.MetricBuilderSpec.UnderTest.foobar already exists
java.lang.IllegalArgumentException: A metric named nl.grons.metrics4.scala.MetricBuilderSpec.UnderTest.foobar already exists
```